### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/322/35/85632235.geojson
+++ b/data/856/322/35/85632235.geojson
@@ -1011,6 +1011,10 @@
     },
     "wof:country":"BW",
     "wof:country_alpha3":"BWA",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"25c0d25e5cfa0975bcdcea2b2adc3d20",
     "wof:hierarchy":[
         {
@@ -1027,7 +1031,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1566630111,
+    "wof:lastmodified":1582318516,
     "wof:name":"Botswana",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.