### PR TITLE
Name updates

### DIFF
--- a/data/856/322/35/85632235.geojson
+++ b/data/856/322/35/85632235.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":50.663717,
-    "geom:area_square_m":579683363205.879883,
+    "geom:area_square_m":579683365485.119507,
     "geom:bbox":"19.998903,-26.907545,29.375304,-17.778158",
     "geom:latitude":-22.187383,
     "geom:longitude":23.814767,
@@ -64,6 +64,9 @@
     "name:arg_x_variant":[
         "Botsuana"
     ],
+    "name:ary_x_preferred":[
+        "\u0628\u0648\u062a\u0633\u0648\u0627\u0646\u0627"
+    ],
     "name:arz_x_preferred":[
         "\u0628\u0648\u062a\u0633\u0648\u0627\u0646\u0627"
     ],
@@ -90,6 +93,9 @@
     ],
     "name:bam_x_variant":[
         "B\u0254tisiwana"
+    ],
+    "name:ban_x_preferred":[
+        "Botswana"
     ],
     "name:bcl_x_preferred":[
         "Botswana"
@@ -175,6 +181,12 @@
     "name:dan_x_preferred":[
         "Botswana"
     ],
+    "name:deu_at_x_preferred":[
+        "Botswana"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Botswana"
+    ],
     "name:deu_x_preferred":[
         "Botswana"
     ],
@@ -195,6 +207,12 @@
     ],
     "name:ell_x_preferred":[
         "\u039c\u03c0\u03bf\u03c4\u03c3\u03bf\u03c5\u03ac\u03bd\u03b1"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Botswana"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Botswana"
     ],
     "name:eng_x_preferred":[
         "Botswana"
@@ -259,6 +277,9 @@
     ],
     "name:gag_x_preferred":[
         "Botsvana"
+    ],
+    "name:gcr_x_preferred":[
+        "Botswana"
     ],
     "name:ger_x_variant":[
         "Botsuana",
@@ -517,6 +538,9 @@
     "name:mon_x_preferred":[
         "\u0411\u043e\u0442\u0441\u0432\u0430\u043d\u0430"
     ],
+    "name:mri_x_preferred":[
+        "Poriwana"
+    ],
     "name:msa_x_preferred":[
         "Botswana"
     ],
@@ -571,6 +595,9 @@
     "name:nov_x_preferred":[
         "Botswana"
     ],
+    "name:nqo_x_preferred":[
+        "\u07d3\u07d0\u07d5\u07d1\u07db\u07ce\u07e5\u07e3\u07ca\u07eb"
+    ],
     "name:nso_x_preferred":[
         "Botswana"
     ],
@@ -618,6 +645,9 @@
         "\u0628\u0648\u0679\u0633\u0648\u0627\u0646\u0627"
     ],
     "name:pol_x_preferred":[
+        "Botswana"
+    ],
+    "name:por_br_x_preferred":[
         "Botswana"
     ],
     "name:por_x_preferred":[
@@ -714,6 +744,12 @@
     "name:srd_x_preferred":[
         "Botzuana"
     ],
+    "name:srp_ec_x_preferred":[
+        "\u0411\u043e\u0446\u0432\u0430\u043d\u0430"
+    ],
+    "name:srp_el_x_preferred":[
+        "Botsvana"
+    ],
     "name:srp_x_preferred":[
         "\u0411\u043e\u0446\u0432\u0430\u043d\u0430"
     ],
@@ -733,6 +769,9 @@
         "Botswana"
     ],
     "name:szl_x_preferred":[
+        "Botswana"
+    ],
+    "name:szy_x_preferred":[
         "Botswana"
     ],
     "name:tam_x_preferred":[
@@ -864,8 +903,14 @@
     "name:zha_x_preferred":[
         "Botswana"
     ],
+    "name:zho_hk_x_preferred":[
+        "\u535a\u8328\u74e6\u7d0d"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Botswana"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u6ce2\u672d\u90a3"
     ],
     "name:zho_x_preferred":[
         "\u6ce2\u672d\u90a3"
@@ -1032,7 +1077,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1583797293,
+    "wof:lastmodified":1587428234,
     "wof:name":"Botswana",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.