### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/582/000/7/1125820007.geojson
+++ b/data/112/582/000/7/1125820007.geojson
@@ -46,10 +46,16 @@
     "name:pol_x_preferred":[
         "Sebina"
     ],
+    "name:por_x_preferred":[
+        "Sebina"
+    ],
     "name:swa_x_preferred":[
         "Sebina"
     ],
     "name:swe_x_preferred":[
+        "Sebina"
+    ],
+    "name:zul_x_preferred":[
         "Sebina"
     ],
     "qs_pg:aaroncc":"BW",
@@ -89,7 +95,7 @@
         }
     ],
     "wof:id":1125820007,
-    "wof:lastmodified":1566630234,
+    "wof:lastmodified":1690863642,
     "wof:name":"Sebina",
     "wof:parent_id":85669627,
     "wof:placetype":"locality",

--- a/data/112/585/811/3/1125858113.geojson
+++ b/data/112/585/811/3/1125858113.geojson
@@ -49,6 +49,9 @@
     "name:pol_x_preferred":[
         "Moiyabana"
     ],
+    "name:por_x_preferred":[
+        "Moiyabana"
+    ],
     "name:rus_x_preferred":[
         "\u041c\u043e\u0439\u044f\u0431\u0430\u043d\u0430"
     ],
@@ -59,6 +62,9 @@
         "Moiyabana"
     ],
     "name:tsn_x_preferred":[
+        "Moiyabana"
+    ],
+    "name:zul_x_preferred":[
         "Moiyabana"
     ],
     "qs_pg:aaroncc":"BW",
@@ -98,7 +104,7 @@
         }
     ],
     "wof:id":1125858113,
-    "wof:lastmodified":1566630234,
+    "wof:lastmodified":1690863642,
     "wof:name":"Moijabana",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/421/167/169/421167169.geojson
+++ b/data/421/167/169/421167169.geojson
@@ -38,6 +38,9 @@
     "name:pol_x_preferred":[
         "Pilikwe"
     ],
+    "name:por_x_preferred":[
+        "Pilikwe"
+    ],
     "name:swa_x_preferred":[
         "Pilikwe"
     ],
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":421167169,
-    "wof:lastmodified":1566630218,
+    "wof:lastmodified":1690863623,
     "wof:name":"Pilikwe",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/421/167/171/421167171.geojson
+++ b/data/421/167/171/421167171.geojson
@@ -50,6 +50,9 @@
     "name:pol_x_preferred":[
         "Mookane"
     ],
+    "name:por_x_preferred":[
+        "Mookane"
+    ],
     "name:swa_x_preferred":[
         "Mookane"
     ],
@@ -58,6 +61,9 @@
     ],
     "name:tsn_x_preferred":[
         "Motsana wa Mookane"
+    ],
+    "name:zul_x_preferred":[
+        "Mookane"
     ],
     "qs:gn_country":"BW",
     "qs:gn_fcode":"PPL",
@@ -107,7 +113,7 @@
         }
     ],
     "wof:id":421167171,
-    "wof:lastmodified":1566630219,
+    "wof:lastmodified":1690863624,
     "wof:name":"Mookane",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/421/167/173/421167173.geojson
+++ b/data/421/167/173/421167173.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Mathangwane"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0627\u062a\u0647\u0627\u0646\u0642\u0648\u0627\u0646"
     ],
@@ -50,6 +53,9 @@
     "name:pol_x_preferred":[
         "Mathangwane"
     ],
+    "name:por_x_preferred":[
+        "Mathangwane"
+    ],
     "name:rus_x_preferred":[
         "\u041c\u0430\u0442\u0445\u0430\u043d\u0433\u0432\u0430\u043d\u0435"
     ],
@@ -67,6 +73,9 @@
     ],
     "name:und_x_variant":[
         "Matangwan Stad"
+    ],
+    "name:zul_x_preferred":[
+        "Mathangwane"
     ],
     "qs:gn_country":"BW",
     "qs:gn_fcode":"PPL",
@@ -112,7 +121,7 @@
         }
     ],
     "wof:id":421167173,
-    "wof:lastmodified":1566630219,
+    "wof:lastmodified":1690863624,
     "wof:name":"Matangwan",
     "wof:parent_id":85669627,
     "wof:placetype":"locality",

--- a/data/421/168/787/421168787.geojson
+++ b/data/421/168/787/421168787.geojson
@@ -23,6 +23,12 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u0633\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u0633\u0627\u0646"
+    ],
+    "name:ast_x_preferred":[
+        "Kasane"
+    ],
     "name:azb_x_preferred":[
         "\u06a9\u0627\u0633\u0627\u0646"
     ],
@@ -124,6 +130,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5361\u85a9\u5167"
+    ],
+    "name:zul_x_preferred":[
+        "Kasane"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Botswana",
@@ -265,7 +274,7 @@
         }
     ],
     "wof:id":421168787,
-    "wof:lastmodified":1636495624,
+    "wof:lastmodified":1690863622,
     "wof:name":"Kasane",
     "wof:parent_id":85669599,
     "wof:placetype":"locality",

--- a/data/421/170/193/421170193.geojson
+++ b/data/421/170/193/421170193.geojson
@@ -20,6 +20,9 @@
     "name:afr_x_preferred":[
         "Thamaga"
     ],
+    "name:ast_x_preferred":[
+        "Thamaga"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u0627\u0645\u0627\u0642\u0627"
     ],
@@ -74,6 +77,9 @@
     "name:pol_x_preferred":[
         "Thamaga"
     ],
+    "name:por_x_preferred":[
+        "Thamaga"
+    ],
     "name:ron_x_preferred":[
         "Thamaga"
     ],
@@ -95,8 +101,14 @@
     "name:tur_x_preferred":[
         "Thamaga"
     ],
+    "name:ukr_x_preferred":[
+        "\u0422\u0430\u043c\u0430\u0433\u0430"
+    ],
     "name:zho_x_preferred":[
         "\u5854\u99ac\u54c8"
+    ],
+    "name:zul_x_preferred":[
+        "Thamaga"
     ],
     "qs:gn_country":"BW",
     "qs:gn_fcode":"PPL",
@@ -147,7 +159,7 @@
         }
     ],
     "wof:id":421170193,
-    "wof:lastmodified":1566630224,
+    "wof:lastmodified":1690863630,
     "wof:name":"Thamaga",
     "wof:parent_id":85669611,
     "wof:placetype":"locality",

--- a/data/421/170/735/421170735.geojson
+++ b/data/421/170/735/421170735.geojson
@@ -23,6 +23,15 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u0646\u064a"
     ],
+    "name:ara_x_variant":[
+        "\u0643\u0627\u0646\u064a\u064a\u0647"
+    ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u0646\u064a\u064a\u0647"
+    ],
+    "name:ast_x_preferred":[
+        "Kanye"
+    ],
     "name:azb_x_preferred":[
         "\u06a9\u0627\u0646\u06cc\u0647"
     ],
@@ -30,7 +39,8 @@
         "\u0413\u043e\u0440\u0430\u0434 \u041a\u0430\u043d\u0435"
     ],
     "name:bel_x_variant":[
-        "\u0413\u043e\u0440\u0430\u0434 \u041a\u0430\u043d'\u0435"
+        "\u0413\u043e\u0440\u0430\u0434 \u041a\u0430\u043d'\u0435",
+        "\u041a\u0430\u043d\u2019\u0435"
     ],
     "name:ben_x_preferred":[
         "\u0995\u09be\u09a8\u09c7"
@@ -179,6 +189,9 @@
     "name:zho_x_preferred":[
         "\u5361\u5167"
     ],
+    "name:zul_x_preferred":[
+        "Kanye"
+    ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Botswana",
     "ne:ADM0_A3":"BWA",
@@ -320,7 +333,7 @@
         }
     ],
     "wof:id":421170735,
-    "wof:lastmodified":1636495626,
+    "wof:lastmodified":1690863630,
     "wof:name":"Kanye",
     "wof:parent_id":85669619,
     "wof:placetype":"locality",

--- a/data/421/170/737/421170737.geojson
+++ b/data/421/170/737/421170737.geojson
@@ -32,6 +32,9 @@
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0427\u0430\u0431\u043e\u043d\u0433"
     ],
+    "name:bel_x_variant":[
+        "\u0427\u0430\u0431\u043e\u043d\u0433"
+    ],
     "name:ben_x_preferred":[
         "\u09a4\u0981\u09b8\u09be\u09ac\u0982"
     ],
@@ -131,6 +134,9 @@
     "name:por_x_preferred":[
         "Tshabong"
     ],
+    "name:pus_x_preferred":[
+        "\u062a\u0634\u0627\u0628\u0648\u0646\u06ab"
+    ],
     "name:ron_x_preferred":[
         "Tshabong"
     ],
@@ -175,6 +181,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5bdf\u90a6"
+    ],
+    "name:zul_x_preferred":[
+        "Tsabong"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Botswana",
@@ -316,7 +325,7 @@
         }
     ],
     "wof:id":421170737,
-    "wof:lastmodified":1636495625,
+    "wof:lastmodified":1690863630,
     "wof:name":"Tshabong",
     "wof:parent_id":85669593,
     "wof:placetype":"locality",

--- a/data/421/170/739/421170739.geojson
+++ b/data/421/170/739/421170739.geojson
@@ -26,6 +26,9 @@
     "name:ceb_x_preferred":[
         "Tonota"
     ],
+    "name:deu_x_preferred":[
+        "Tonota"
+    ],
     "name:eng_x_preferred":[
         "Tonota"
     ],
@@ -50,6 +53,9 @@
     "name:pol_x_preferred":[
         "Tonota"
     ],
+    "name:por_x_preferred":[
+        "Tonota"
+    ],
     "name:ron_x_preferred":[
         "Tonota"
     ],
@@ -68,11 +74,17 @@
     "name:tsn_x_preferred":[
         "Tonota"
     ],
+    "name:ukr_x_preferred":[
+        "\u0422\u043e\u043d\u043e\u0442\u0430"
+    ],
     "name:und_x_variant":[
         "Tonoto"
     ],
     "name:zho_x_preferred":[
         "\u6258\u8afe\u5854"
+    ],
+    "name:zul_x_preferred":[
+        "Tonota"
     ],
     "qs:gn_country":"BW",
     "qs:gn_fcode":"PPL",
@@ -119,7 +131,7 @@
         }
     ],
     "wof:id":421170739,
-    "wof:lastmodified":1566630224,
+    "wof:lastmodified":1690863630,
     "wof:name":"Tonota",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/421/170/743/421170743.geojson
+++ b/data/421/170/743/421170743.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_preferred":[
         "\u0633\u064a\u0644\u064a\u0628\u064a-\u0641\u064a\u0643\u0648\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u064a\u0644\u064a\u0628\u0649 \u0641\u064a\u0643\u0648\u0649"
+    ],
     "name:ast_x_preferred":[
         "Selebi-Phikwe"
     ],
@@ -164,6 +167,9 @@
     "name:zho_x_preferred":[
         "\u585e\u83b1\u6bd4-\u76ae\u594e"
     ],
+    "name:zul_x_preferred":[
+        "Selebi-Phikwe"
+    ],
     "qs:gn_country":"BW",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":933099,
@@ -213,7 +219,7 @@
         }
     ],
     "wof:id":421170743,
-    "wof:lastmodified":1566630224,
+    "wof:lastmodified":1690863631,
     "wof:name":"Selebi-Pikwe",
     "wof:parent_id":85669645,
     "wof:placetype":"locality",

--- a/data/421/171/237/421171237.geojson
+++ b/data/421/171/237/421171237.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_preferred":[
         "\u063a\u0648\u0627\u0646\u064a\u0646\u063a"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0648\u0627\u0646\u064a\u0646\u062c"
+    ],
     "name:ast_x_preferred":[
         "Jwaneng"
     ],
@@ -164,6 +167,9 @@
     "name:zho_x_preferred":[
         "\u6731\u74e6\u80fd"
     ],
+    "name:zul_x_preferred":[
+        "Jwaneng"
+    ],
     "qs:gn_country":"BW",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":8308627,
@@ -213,7 +219,7 @@
         }
     ],
     "wof:id":421171237,
-    "wof:lastmodified":1636495626,
+    "wof:lastmodified":1690863632,
     "wof:name":"Jwaneng",
     "wof:parent_id":85669653,
     "wof:placetype":"locality",

--- a/data/421/172/743/421172743.geojson
+++ b/data/421/172/743/421172743.geojson
@@ -47,6 +47,9 @@
     "name:pol_x_preferred":[
         "Oodi"
     ],
+    "name:por_x_preferred":[
+        "Oodi"
+    ],
     "name:spa_x_preferred":[
         "Oodi"
     ],
@@ -58,6 +61,9 @@
     ],
     "name:tsn_x_preferred":[
         "Motsana wa Oodi"
+    ],
+    "name:zul_x_preferred":[
+        "Oodi"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -104,7 +110,7 @@
         }
     ],
     "wof:id":421172743,
-    "wof:lastmodified":1566630221,
+    "wof:lastmodified":1690863626,
     "wof:name":"Oodi",
     "wof:parent_id":85669631,
     "wof:placetype":"locality",

--- a/data/421/173/155/421173155.geojson
+++ b/data/421/173/155/421173155.geojson
@@ -23,11 +23,17 @@
     "name:ara_x_preferred":[
         "\u0645\u0627\u0648\u0646"
     ],
+    "name:ast_x_preferred":[
+        "Maun"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0627\u0648\u0646"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041c\u0430\u045e\u043d"
+    ],
+    "name:bel_x_variant":[
+        "\u041c\u0430\u045e\u043d"
     ],
     "name:ben_x_preferred":[
         "\u09ae\u09be\u0989\u09a8"
@@ -179,6 +185,9 @@
     "name:zho_x_preferred":[
         "\u99ac\u7fc1"
     ],
+    "name:zul_x_preferred":[
+        "Maun"
+    ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Botswana",
     "ne:ADM0_A3":"BWA",
@@ -316,7 +325,7 @@
         }
     ],
     "wof:id":421173155,
-    "wof:lastmodified":1636495624,
+    "wof:lastmodified":1690863625,
     "wof:name":"Maun",
     "wof:parent_id":85669599,
     "wof:placetype":"locality",

--- a/data/421/173/961/421173961.geojson
+++ b/data/421/173/961/421173961.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":9.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Mogoditshane"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0648\u0642\u0648\u062f\u06cc\u062a\u0634\u0627\u0646"
     ],
@@ -98,6 +101,9 @@
     "name:tur_x_preferred":[
         "Mogoditshane"
     ],
+    "name:ukr_x_preferred":[
+        "\u041c\u043e\u0433\u043e\u0434\u0456\u0442\u0448\u0430\u043d\u0435"
+    ],
     "name:und_x_variant":[
         "Mogoditsane"
     ],
@@ -106,6 +112,9 @@
     ],
     "name:zho_x_preferred":[
         "\u83ab\u6208\u8fea\u6c99\u5167"
+    ],
+    "name:zul_x_preferred":[
+        "Mogoditshane"
     ],
     "qs:gn_country":"BW",
     "qs:gn_fcode":"PPL",
@@ -157,7 +166,7 @@
         }
     ],
     "wof:id":421173961,
-    "wof:lastmodified":1566630220,
+    "wof:lastmodified":1690863625,
     "wof:name":"Mogoditshane",
     "wof:parent_id":85669631,
     "wof:placetype":"locality",

--- a/data/421/174/049/421174049.geojson
+++ b/data/421/174/049/421174049.geojson
@@ -38,10 +38,16 @@
     "name:pol_x_preferred":[
         "Paje"
     ],
+    "name:por_x_preferred":[
+        "Paje"
+    ],
     "name:swa_x_preferred":[
         "Paje"
     ],
     "name:swe_x_preferred":[
+        "Paje"
+    ],
+    "name:tsn_x_preferred":[
         "Paje"
     ],
     "qs:gn_country":"BW",
@@ -91,7 +97,7 @@
         }
     ],
     "wof:id":421174049,
-    "wof:lastmodified":1566630219,
+    "wof:lastmodified":1690863624,
     "wof:name":"Paje",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/421/176/845/421176845.geojson
+++ b/data/421/176/845/421176845.geojson
@@ -38,6 +38,9 @@
     "name:pol_x_preferred":[
         "Mathathane"
     ],
+    "name:por_x_preferred":[
+        "Mathathane"
+    ],
     "name:swa_x_preferred":[
         "Mathathane"
     ],
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421176845,
-    "wof:lastmodified":1566630225,
+    "wof:lastmodified":1690863632,
     "wof:name":"Mathathane",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/421/177/709/421177709.geojson
+++ b/data/421/177/709/421177709.geojson
@@ -47,6 +47,9 @@
     "name:ita_x_preferred":[
         "Tlokweng"
     ],
+    "name:mlg_x_preferred":[
+        "Tlokweng"
+    ],
     "name:nld_x_preferred":[
         "Tlokweng"
     ],
@@ -83,8 +86,14 @@
     "name:tur_x_preferred":[
         "Tlokweng"
     ],
+    "name:ukr_x_preferred":[
+        "\u0422\u043b\u043e\u043a\u0432\u0435\u043d\u0433"
+    ],
     "name:zho_x_preferred":[
         "\u7279\u6d1b\u6606"
+    ],
+    "name:zul_x_preferred":[
+        "Tlokweng"
     ],
     "qs:gn_country":"BW",
     "qs:gn_fcode":"PPL",
@@ -132,7 +141,7 @@
         }
     ],
     "wof:id":421177709,
-    "wof:lastmodified":1566630224,
+    "wof:lastmodified":1690863631,
     "wof:name":"Tlokweng",
     "wof:parent_id":85669631,
     "wof:placetype":"locality",

--- a/data/421/177/971/421177971.geojson
+++ b/data/421/177/971/421177971.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0648\u062a\u0634\u0648\u062f\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0648\u062a\u0634\u0648\u062f\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0648\u0686\u0648\u062f\u06cc"
     ],
@@ -125,6 +128,9 @@
     "name:por_x_preferred":[
         "Mochudi"
     ],
+    "name:pus_x_preferred":[
+        "\u0645\u0648\u0686\u0648\u062f\u064a"
+    ],
     "name:ron_x_preferred":[
         "Mochudi"
     ],
@@ -172,6 +178,9 @@
     ],
     "name:zho_x_preferred":[
         "\u83ab\u4e18\u8fea"
+    ],
+    "name:zul_x_preferred":[
+        "Mochudi"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Botswana",
@@ -314,7 +323,7 @@
         }
     ],
     "wof:id":421177971,
-    "wof:lastmodified":1636495626,
+    "wof:lastmodified":1690863631,
     "wof:name":"Mochudi",
     "wof:parent_id":85669607,
     "wof:placetype":"locality",

--- a/data/421/180/381/421180381.geojson
+++ b/data/421/180/381/421180381.geojson
@@ -44,6 +44,9 @@
     "name:pol_x_preferred":[
         "Botlhapatlou"
     ],
+    "name:por_x_preferred":[
+        "Botlhapatlou"
+    ],
     "name:swa_x_preferred":[
         "Botlhapatlou"
     ],
@@ -51,6 +54,9 @@
         "Botlhapatlou"
     ],
     "name:tsn_x_preferred":[
+        "Botlhapatlou"
+    ],
+    "name:uzb_x_preferred":[
         "Botlhapatlou"
     ],
     "qs:gn_country":"BW",
@@ -101,7 +107,7 @@
         }
     ],
     "wof:id":421180381,
-    "wof:lastmodified":1566630220,
+    "wof:lastmodified":1690863625,
     "wof:name":"Botlapatla",
     "wof:parent_id":85669611,
     "wof:placetype":"locality",

--- a/data/421/180/383/421180383.geojson
+++ b/data/421/180/383/421180383.geojson
@@ -38,6 +38,9 @@
     "name:pol_x_preferred":[
         "Bonwapitse"
     ],
+    "name:por_x_preferred":[
+        "Bonwapitse"
+    ],
     "name:swa_x_preferred":[
         "Bonwapitse"
     ],
@@ -49,6 +52,9 @@
     ],
     "name:und_x_variant":[
         "Bonapitse"
+    ],
+    "name:uzb_x_preferred":[
+        "Bonwapitse"
     ],
     "qs:gn_country":"BW",
     "qs:gn_fcode":"PPL",
@@ -98,7 +104,7 @@
         }
     ],
     "wof:id":421180383,
-    "wof:lastmodified":1566630219,
+    "wof:lastmodified":1690863625,
     "wof:name":"Bonwapitse",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/421/180/385/421180385.geojson
+++ b/data/421/180/385/421180385.geojson
@@ -44,6 +44,9 @@
     "name:pol_x_preferred":[
         "Sefophe"
     ],
+    "name:por_x_preferred":[
+        "Sefophe"
+    ],
     "name:spa_x_preferred":[
         "Sefophe"
     ],
@@ -58,6 +61,9 @@
     ],
     "name:tsn_x_variant":[
         "Bonwapitse"
+    ],
+    "name:zul_x_preferred":[
+        "Sefophe"
     ],
     "qs:gn_country":"BW",
     "qs:gn_fcode":"PPL",
@@ -107,7 +113,7 @@
         }
     ],
     "wof:id":421180385,
-    "wof:lastmodified":1566630220,
+    "wof:lastmodified":1690863625,
     "wof:name":"Sefophe",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/421/181/643/421181643.geojson
+++ b/data/421/181/643/421181643.geojson
@@ -23,6 +23,9 @@
     "name:ceb_x_preferred":[
         "Seronga"
     ],
+    "name:dan_x_preferred":[
+        "Seronga"
+    ],
     "name:ell_x_preferred":[
         "\u03a3\u03b5\u03c1\u03cc\u03bd\u03b3\u03ba\u03b1"
     ],
@@ -56,6 +59,9 @@
     "name:pol_x_preferred":[
         "Seronga"
     ],
+    "name:por_x_preferred":[
+        "Seronga"
+    ],
     "name:rus_x_preferred":[
         "\u0421\u0435\u0440\u043e\u043d\u0433\u0430"
     ],
@@ -66,6 +72,9 @@
         "Seronga"
     ],
     "name:tsn_x_preferred":[
+        "Seronga"
+    ],
+    "name:zul_x_preferred":[
         "Seronga"
     ],
     "qs:gn_country":"BW",
@@ -115,7 +124,7 @@
         }
     ],
     "wof:id":421181643,
-    "wof:lastmodified":1566630221,
+    "wof:lastmodified":1690863627,
     "wof:name":"Seronga",
     "wof:parent_id":85669599,
     "wof:placetype":"locality",

--- a/data/421/182/757/421182757.geojson
+++ b/data/421/182/757/421182757.geojson
@@ -47,6 +47,9 @@
     "name:pol_x_preferred":[
         "Tshane"
     ],
+    "name:por_x_preferred":[
+        "Tshane"
+    ],
     "name:swa_x_preferred":[
         "Tshane"
     ],
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421182757,
-    "wof:lastmodified":1566630225,
+    "wof:lastmodified":1690863632,
     "wof:name":"Tshane",
     "wof:parent_id":85669593,
     "wof:placetype":"locality",

--- a/data/421/183/401/421183401.geojson
+++ b/data/421/183/401/421183401.geojson
@@ -26,6 +26,9 @@
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041c\u0430\u0441\u0443\u043d\u0433\u0430"
     ],
+    "name:bel_x_variant":[
+        "\u041c\u0430\u0441\u0443\u043d\u0433\u0430"
+    ],
     "name:bul_x_preferred":[
         "\u041c\u0430\u0441\u0443\u043d\u0433\u0430"
     ],
@@ -47,6 +50,9 @@
     "name:fas_x_variant":[
         "\u0645\u0627\u0633\u0648\u0646\u06af\u0627"
     ],
+    "name:fin_x_preferred":[
+        "Masunga"
+    ],
     "name:fra_x_preferred":[
         "Masunga"
     ],
@@ -55,6 +61,9 @@
     ],
     "name:ita_x_preferred":[
         "Masunga"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30de\u30b9\u30f3\u30ac"
     ],
     "name:lit_x_preferred":[
         "Masunga"
@@ -69,6 +78,9 @@
         "Masunga"
     ],
     "name:pol_x_preferred":[
+        "Masunga"
+    ],
+    "name:por_x_preferred":[
         "Masunga"
     ],
     "name:ron_x_preferred":[
@@ -89,6 +101,9 @@
     "name:tsn_x_preferred":[
         "Motse wa Masunga"
     ],
+    "name:tsn_x_variant":[
+        "Masunga"
+    ],
     "name:tur_x_preferred":[
         "Masunga"
     ],
@@ -97,6 +112,9 @@
     ],
     "name:und_x_variant":[
         "Masungas"
+    ],
+    "name:zul_x_preferred":[
+        "Masunga"
     ],
     "qs:gn_country":"BW",
     "qs:gn_fcode":"PPL",
@@ -144,7 +162,7 @@
         }
     ],
     "wof:id":421183401,
-    "wof:lastmodified":1566630225,
+    "wof:lastmodified":1690863632,
     "wof:name":"Masunga",
     "wof:parent_id":85669627,
     "wof:placetype":"locality",

--- a/data/421/183/811/421183811.geojson
+++ b/data/421/183/811/421183811.geojson
@@ -23,6 +23,15 @@
     "name:ara_x_preferred":[
         "\u0631\u0627\u0645\u0648\u062a\u0633\u0648\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0631\u0627\u0645\u0648\u062a\u0633\u0648\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Ramotswa"
+    ],
+    "name:azb_x_preferred":[
+        "\u0631\u0627\u0645\u0648\u062a\u0633\u0648\u0627"
+    ],
     "name:ben_x_preferred":[
         "\u09b0\u09be\u09ae\u09cb\u09ce\u09b8\u09be\u0981"
     ],
@@ -107,6 +116,9 @@
     "name:por_x_preferred":[
         "Ramotswa"
     ],
+    "name:pus_x_preferred":[
+        "\u0631\u0627\u0645\u0648\u062a\u0633\u0648\u0627"
+    ],
     "name:ron_x_preferred":[
         "Ramotswa"
     ],
@@ -154,6 +166,9 @@
     ],
     "name:zho_x_preferred":[
         "\u62c9\u83ab\u8328\u74e6"
+    ],
+    "name:zul_x_preferred":[
+        "Ramotswa"
     ],
     "qs:gn_country":"BW",
     "qs:gn_fcode":"PPL",
@@ -204,7 +219,7 @@
         }
     ],
     "wof:id":421183811,
-    "wof:lastmodified":1566630224,
+    "wof:lastmodified":1690863631,
     "wof:name":"Ramotswa",
     "wof:parent_id":85669615,
     "wof:placetype":"locality",

--- a/data/421/186/333/421186333.geojson
+++ b/data/421/186/333/421186333.geojson
@@ -31,8 +31,14 @@
     "name:fra_x_preferred":[
         "Katima Mulilo"
     ],
+    "name:fra_x_variant":[
+        "Katima Mulilo Rural"
+    ],
     "name:ita_x_preferred":[
         "Katima Mulilo Rurale"
+    ],
+    "name:nan_x_preferred":[
+        "Katima Mulilo Chng-kha So\u00e1n-k\u00ed-khu"
     ],
     "name:nld_x_preferred":[
         "Katima Mulilo Rural"
@@ -41,6 +47,9 @@
         "\u041a\u0430\u0442\u0438\u043c\u0430-\u041c\u0443\u043b\u0438\u043b\u043e \u041b\u044d\u043d\u0434"
     ],
     "name:spa_x_preferred":[
+        "Katima Mulilo Rural"
+    ],
+    "name:zul_x_preferred":[
         "Katima Mulilo Rural"
     ],
     "qs:gn_country":null,
@@ -86,7 +95,7 @@
         }
     ],
     "wof:id":421186333,
-    "wof:lastmodified":1566630221,
+    "wof:lastmodified":1690863626,
     "wof:name":"Katima Mulilo Rural",
     "wof:parent_id":85669599,
     "wof:placetype":"county",

--- a/data/421/188/199/421188199.geojson
+++ b/data/421/188/199/421188199.geojson
@@ -47,6 +47,9 @@
     "name:pol_x_preferred":[
         "Pandamatenga"
     ],
+    "name:por_x_preferred":[
+        "Pandamatenga"
+    ],
     "name:rus_x_preferred":[
         "\u041f\u0430\u043d\u0434\u0430\u043c\u0430\u0442\u0435\u043d\u0433\u0430"
     ],
@@ -58,6 +61,9 @@
     ],
     "name:tsn_x_preferred":[
         "Motse wa Pandamatenga"
+    ],
+    "name:tsn_x_variant":[
+        "Pandamatenga"
     ],
     "qs:gn_country":"BW",
     "qs:gn_fcode":"PPL",
@@ -107,7 +113,7 @@
         }
     ],
     "wof:id":421188199,
-    "wof:lastmodified":1566630221,
+    "wof:lastmodified":1690863626,
     "wof:name":"Pandamatenga",
     "wof:parent_id":85669599,
     "wof:placetype":"locality",

--- a/data/421/188/851/421188851.geojson
+++ b/data/421/188/851/421188851.geojson
@@ -50,6 +50,12 @@
     "name:pol_x_preferred":[
         "Kumakwane"
     ],
+    "name:por_x_preferred":[
+        "Kumakwane"
+    ],
+    "name:pus_x_preferred":[
+        "\u06a9\u0648\u0645\u0627\u06a9\u0648\u0627"
+    ],
     "name:rus_x_preferred":[
         "\u041a\u0443\u043c\u0430\u043a\u0432\u0430\u043d\u0435"
     ],
@@ -62,8 +68,17 @@
     "name:swe_x_preferred":[
         "Kumakwane"
     ],
+    "name:tsn_x_preferred":[
+        "Kumakwane"
+    ],
     "name:ukr_x_preferred":[
         "Matlapaneng"
+    ],
+    "name:uzb_x_preferred":[
+        "Kumakwane"
+    ],
+    "name:zul_x_preferred":[
+        "Kumakwane"
     ],
     "qs:gn_country":"BW",
     "qs:gn_fcode":"PPL",
@@ -112,7 +127,7 @@
         }
     ],
     "wof:id":421188851,
-    "wof:lastmodified":1566630221,
+    "wof:lastmodified":1690863626,
     "wof:name":"Kumakwane",
     "wof:parent_id":85669611,
     "wof:placetype":"locality",

--- a/data/421/190/669/421190669.geojson
+++ b/data/421/190/669/421190669.geojson
@@ -28,6 +28,12 @@
     "name:ara_x_preferred":[
         "\u0628\u064a\u062a\u0628\u0631\u064a\u062f\u062c"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u064a\u062a\u0628\u0631\u064a\u062f\u062c"
+    ],
+    "name:ast_x_preferred":[
+        "Beitbridge"
+    ],
     "name:bar_x_preferred":[
         "Beitbridge"
     ],
@@ -38,6 +44,9 @@
         "\u0411\u0435\u0438\u0442\u0431\u0440\u0438\u0434\u0433\u0435"
     ],
     "name:ceb_x_preferred":[
+        "Beitbridge"
+    ],
+    "name:ces_x_preferred":[
         "Beitbridge"
     ],
     "name:dan_x_preferred":[
@@ -118,6 +127,9 @@
     "name:srp_x_preferred":[
         "\u0411\u0430\u0458\u0442\u0431\u0440\u0438\u045f"
     ],
+    "name:swa_x_preferred":[
+        "Beitbridge"
+    ],
     "name:swe_x_preferred":[
         "Beitbridge"
     ],
@@ -135,6 +147,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8c9d\u7279\u6a4b"
+    ],
+    "name:zul_x_preferred":[
+        "Beitbridge"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -183,7 +198,7 @@
         }
     ],
     "wof:id":421190669,
-    "wof:lastmodified":1636495625,
+    "wof:lastmodified":1690863628,
     "wof:name":"Beitbridge",
     "wof:parent_id":85669601,
     "wof:placetype":"county",

--- a/data/421/192/769/421192769.geojson
+++ b/data/421/192/769/421192769.geojson
@@ -20,6 +20,9 @@
     "name:afr_x_preferred":[
         "Francistown"
     ],
+    "name:aka_x_preferred":[
+        "Francistown"
+    ],
     "name:ara_x_preferred":[
         "\u0641\u0631\u0627\u0646\u0633\u064a\u0633"
     ],
@@ -34,6 +37,9 @@
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0424\u0440\u0430\u043d\u0441\u0456\u0441\u0442\u0430\u045e\u043d"
+    ],
+    "name:bel_x_variant":[
+        "\u0424\u0440\u0430\u043d\u0441\u0456\u0441\u0442\u0430\u045e\u043d"
     ],
     "name:ben_x_preferred":[
         "\u09ab\u09cd\u09b0\u09be\u099e\u09cd\u099a\u09bf\u09b8\u099f\u09be\u0989\u09a8"
@@ -104,6 +110,9 @@
     "name:hun_x_preferred":[
         "Francistown"
     ],
+    "name:hye_x_preferred":[
+        "\u0556\u0580\u0561\u0576\u057d\u056b\u057d\u0569\u0561\u0578\u0582\u0576"
+    ],
     "name:ind_x_preferred":[
         "Francistown"
     ],
@@ -164,6 +173,9 @@
     "name:spa_x_preferred":[
         "Francistown"
     ],
+    "name:srp_x_preferred":[
+        "\u0424\u0440\u0430\u043d\u0441\u0438\u0441\u0442\u0430\u0443\u043d"
+    ],
     "name:swe_x_preferred":[
         "Francistown"
     ],
@@ -199,6 +211,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5f17\u6717\u897f\u65af\u6566"
+    ],
+    "name:zul_x_preferred":[
+        "Francistown"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Botswana",
@@ -341,7 +356,7 @@
         }
     ],
     "wof:id":421192769,
-    "wof:lastmodified":1636495624,
+    "wof:lastmodified":1690863623,
     "wof:name":"Francistown",
     "wof:parent_id":85669635,
     "wof:placetype":"locality",

--- a/data/421/194/049/421194049.geojson
+++ b/data/421/194/049/421194049.geojson
@@ -29,6 +29,9 @@
     "name:ita_x_preferred":[
         "Mosetse"
     ],
+    "name:jpn_x_preferred":[
+        "\u30e2\u30bb\u30c4\u30a7"
+    ],
     "name:mlg_x_preferred":[
         "Mosetse"
     ],
@@ -36,6 +39,9 @@
         "Mosetse"
     ],
     "name:pol_x_preferred":[
+        "Mosetse"
+    ],
+    "name:por_x_preferred":[
         "Mosetse"
     ],
     "name:swa_x_preferred":[
@@ -46,6 +52,9 @@
     ],
     "name:tsn_x_preferred":[
         "Motsana wa Mosetse"
+    ],
+    "name:tsn_x_variant":[
+        "Mosetse"
     ],
     "qs:gn_country":"BW",
     "qs:gn_fcode":"PPL",
@@ -94,7 +103,7 @@
         }
     ],
     "wof:id":421194049,
-    "wof:lastmodified":1566630218,
+    "wof:lastmodified":1690863623,
     "wof:name":"Mosetse",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/421/194/587/421194587.geojson
+++ b/data/421/194/587/421194587.geojson
@@ -47,6 +47,9 @@
     "name:pol_x_preferred":[
         "Maunatlala"
     ],
+    "name:por_x_preferred":[
+        "Maunatlala"
+    ],
     "name:swa_x_preferred":[
         "Maunatlala"
     ],
@@ -58,6 +61,9 @@
     ],
     "name:und_x_variant":[
         "Monnatlala"
+    ],
+    "name:zul_x_preferred":[
+        "Maunatlala"
     ],
     "qs:gn_country":"BW",
     "qs:gn_fcode":"PPL",
@@ -107,7 +113,7 @@
         }
     ],
     "wof:id":421194587,
-    "wof:lastmodified":1566630218,
+    "wof:lastmodified":1690863623,
     "wof:name":"Maunatlala",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/421/194/589/421194589.geojson
+++ b/data/421/194/589/421194589.geojson
@@ -44,6 +44,9 @@
     "name:pol_x_preferred":[
         "Makwate"
     ],
+    "name:por_x_preferred":[
+        "Makwate"
+    ],
     "name:swa_x_preferred":[
         "Makwate"
     ],
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":421194589,
-    "wof:lastmodified":1566630218,
+    "wof:lastmodified":1690863623,
     "wof:name":"Makwata",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/421/196/699/421196699.geojson
+++ b/data/421/196/699/421196699.geojson
@@ -38,6 +38,9 @@
     "name:pol_x_preferred":[
         "Kobojango"
     ],
+    "name:por_x_preferred":[
+        "Kobojango"
+    ],
     "name:swa_x_preferred":[
         "Kobojango"
     ],
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":421196699,
-    "wof:lastmodified":1566630222,
+    "wof:lastmodified":1690863628,
     "wof:name":"Gobojango",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/421/196/701/421196701.geojson
+++ b/data/421/196/701/421196701.geojson
@@ -47,6 +47,12 @@
     "name:pol_x_preferred":[
         "Machaneng"
     ],
+    "name:por_x_preferred":[
+        "Machaneng"
+    ],
+    "name:rus_x_preferred":[
+        "\u041c\u0430\u0447\u0430\u043d\u0435\u043d\u0433"
+    ],
     "name:swa_x_preferred":[
         "Machaneng"
     ],
@@ -55,6 +61,9 @@
     ],
     "name:tsn_x_preferred":[
         "Motsana wa Machaneng"
+    ],
+    "name:tsn_x_variant":[
+        "Machaneng"
     ],
     "name:und_x_variant":[
         "Machenen"
@@ -106,7 +115,7 @@
         }
     ],
     "wof:id":421196701,
-    "wof:lastmodified":1566630222,
+    "wof:lastmodified":1690863627,
     "wof:name":"Machaneng",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/421/196/703/421196703.geojson
+++ b/data/421/196/703/421196703.geojson
@@ -41,6 +41,9 @@
     "name:pol_x_preferred":[
         "Tamasane"
     ],
+    "name:por_x_preferred":[
+        "Tamasane"
+    ],
     "name:swa_x_preferred":[
         "Tamasane"
     ],
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":421196703,
-    "wof:lastmodified":1566630222,
+    "wof:lastmodified":1690863627,
     "wof:name":"Tamasane",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/421/196/705/421196705.geojson
+++ b/data/421/196/705/421196705.geojson
@@ -50,6 +50,9 @@
     "name:pol_x_preferred":[
         "Tobane"
     ],
+    "name:por_x_preferred":[
+        "Tobane"
+    ],
     "name:swa_x_preferred":[
         "Tobane"
     ],
@@ -57,6 +60,9 @@
         "Tobane"
     ],
     "name:tsn_x_preferred":[
+        "Tobane"
+    ],
+    "name:zul_x_preferred":[
         "Tobane"
     ],
     "qs:gn_country":"BW",
@@ -105,7 +111,7 @@
         }
     ],
     "wof:id":421196705,
-    "wof:lastmodified":1566630222,
+    "wof:lastmodified":1690863627,
     "wof:name":"Tobane",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/421/197/081/421197081.geojson
+++ b/data/421/197/081/421197081.geojson
@@ -44,6 +44,9 @@
     "name:pol_x_preferred":[
         "Khakhea"
     ],
+    "name:por_x_preferred":[
+        "Khakhea"
+    ],
     "name:swa_x_preferred":[
         "Khakhea"
     ],
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":421197081,
-    "wof:lastmodified":1566630223,
+    "wof:lastmodified":1690863628,
     "wof:name":"Khakhea",
     "wof:parent_id":85669619,
     "wof:placetype":"locality",

--- a/data/421/197/383/421197383.geojson
+++ b/data/421/197/383/421197383.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0648\u0644\u0628\u0648\u0644\u0648\u0644\u0627"
     ],
+    "name:ast_x_preferred":[
+        "Molepolole"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0648\u0644\u067e\u0648\u0644\u0648\u0644\u0647"
     ],
@@ -88,6 +91,9 @@
     ],
     "name:hun_x_preferred":[
         "Molepolole"
+    ],
+    "name:hye_x_preferred":[
+        "\u0544\u0578\u056c\u0565\u057a\u0578\u056c\u0578\u056c"
     ],
     "name:ind_x_preferred":[
         "Molepolole"
@@ -179,14 +185,23 @@
     "name:urd_x_preferred":[
         "\u0645\u0648\u0644\u06cc\u067e\u0648\u0644\u0648\u0644\u06cc"
     ],
+    "name:uzb_x_preferred":[
+        "Molepolole"
+    ],
     "name:vep_x_preferred":[
         "Molepolole"
     ],
     "name:vie_x_preferred":[
         "Molepolole"
     ],
+    "name:war_x_preferred":[
+        "Molepolole"
+    ],
     "name:zho_x_preferred":[
         "\u83ab\u840a\u6ce2\u6d1b\u840a"
+    ],
+    "name:zul_x_preferred":[
+        "Molepolole"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Botswana",
@@ -329,7 +344,7 @@
         }
     ],
     "wof:id":421197383,
-    "wof:lastmodified":1636495625,
+    "wof:lastmodified":1690863628,
     "wof:name":"Molepolole",
     "wof:parent_id":85669611,
     "wof:placetype":"locality",

--- a/data/421/198/591/421198591.geojson
+++ b/data/421/198/591/421198591.geojson
@@ -20,8 +20,14 @@
     "name:afr_x_preferred":[
         "Moshupa"
     ],
+    "name:ast_x_preferred":[
+        "Moshupa"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0648\u0634\u0648\u067e\u0627"
+    ],
+    "name:aze_x_preferred":[
+        "Mo\u015fupa"
     ],
     "name:ceb_x_preferred":[
         "Mosopa"
@@ -59,6 +65,9 @@
     "name:pol_x_preferred":[
         "Moshupa"
     ],
+    "name:por_x_preferred":[
+        "Moshupa"
+    ],
     "name:ron_x_preferred":[
         "Moshupa"
     ],
@@ -74,11 +83,20 @@
     "name:swe_x_preferred":[
         "Moshupa"
     ],
+    "name:tgk_x_preferred":[
+        "\u041c\u043e\u0448\u0443\u043f\u0430"
+    ],
     "name:tsn_x_preferred":[
         "Moshupa"
     ],
+    "name:ukr_x_preferred":[
+        "\u041c\u043e\u0448\u0443\u043f\u0430"
+    ],
     "name:zho_x_preferred":[
         "\u83ab\u8212\u5e15"
+    ],
+    "name:zul_x_preferred":[
+        "Moshupa"
     ],
     "qs:gn_country":"BW",
     "qs:gn_fcode":"PPL",
@@ -129,7 +147,7 @@
         }
     ],
     "wof:id":421198591,
-    "wof:lastmodified":1566630221,
+    "wof:lastmodified":1690863627,
     "wof:name":"Mosopa",
     "wof:parent_id":85669619,
     "wof:placetype":"locality",

--- a/data/421/199/009/421199009.geojson
+++ b/data/421/199/009/421199009.geojson
@@ -50,6 +50,9 @@
     "name:pol_x_preferred":[
         "Otse"
     ],
+    "name:por_x_preferred":[
+        "Otse"
+    ],
     "name:spa_x_preferred":[
         "Otse"
     ],
@@ -67,6 +70,9 @@
     ],
     "name:zho_x_preferred":[
         "\u840a\u7279\u62c9\u5361\u5167"
+    ],
+    "name:zul_x_preferred":[
+        "Otse"
     ],
     "qs:gn_country":"BW",
     "qs:gn_fcode":"PPL",
@@ -113,7 +119,7 @@
         }
     ],
     "wof:id":421199009,
-    "wof:lastmodified":1566630223,
+    "wof:lastmodified":1690863629,
     "wof:name":"Otse",
     "wof:parent_id":85669615,
     "wof:placetype":"locality",

--- a/data/421/199/011/421199011.geojson
+++ b/data/421/199/011/421199011.geojson
@@ -50,6 +50,9 @@
     "name:pol_x_preferred":[
         "Letlhakeng"
     ],
+    "name:por_x_preferred":[
+        "Letlhakeng"
+    ],
     "name:spa_x_preferred":[
         "Letlhakeng"
     ],
@@ -67,6 +70,9 @@
     ],
     "name:zho_x_preferred":[
         "\u840a\u7279\u62c9\u80af"
+    ],
+    "name:zul_x_preferred":[
+        "Letlhakeng"
     ],
     "qs:gn_country":"BW",
     "qs:gn_fcode":"PPL",
@@ -116,7 +122,7 @@
         }
     ],
     "wof:id":421199011,
-    "wof:lastmodified":1566630223,
+    "wof:lastmodified":1690863629,
     "wof:name":"Letlhakeng",
     "wof:parent_id":85669611,
     "wof:placetype":"locality",

--- a/data/421/199/013/421199013.geojson
+++ b/data/421/199/013/421199013.geojson
@@ -17,10 +17,16 @@
     "mz:is_current":1,
     "mz:min_zoom":10.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Letlhakane"
+    ],
     "name:azb_x_preferred":[
         "\u0644\u062a\u0644\u0647\u0627\u06a9\u0627\u0646"
     ],
     "name:ceb_x_preferred":[
+        "Letlhakane"
+    ],
+    "name:dan_x_preferred":[
         "Letlhakane"
     ],
     "name:deu_x_preferred":[
@@ -30,6 +36,9 @@
         "\u039b\u03b5\u03c4\u03bb\u03b1\u03ba\u03ac\u03bd\u03b5"
     ],
     "name:eng_x_preferred":[
+        "Letlhakane"
+    ],
+    "name:fao_x_preferred":[
         "Letlhakane"
     ],
     "name:fas_x_preferred":[
@@ -44,6 +53,9 @@
     "name:ita_x_preferred":[
         "Letlhakane"
     ],
+    "name:kal_x_preferred":[
+        "Letlhakane"
+    ],
     "name:ltz_x_preferred":[
         "Letlhakane"
     ],
@@ -53,7 +65,16 @@
     "name:nld_x_preferred":[
         "Letlhakane"
     ],
+    "name:nno_x_preferred":[
+        "Letlhakane"
+    ],
+    "name:nob_x_preferred":[
+        "Letlhakane"
+    ],
     "name:pol_x_preferred":[
+        "Letlhakane"
+    ],
+    "name:por_x_preferred":[
         "Letlhakane"
     ],
     "name:ron_x_preferred":[
@@ -77,11 +98,17 @@
     "name:tur_x_preferred":[
         "Letlhakane"
     ],
+    "name:ukr_x_preferred":[
+        "\u041b\u0435\u0442\u043b\u043a\u0445\u0430\u043a\u0430\u043d\u0435"
+    ],
     "name:und_x_variant":[
         "Letlhakawe"
     ],
     "name:zho_x_preferred":[
         "\u840a\u7279\u62c9\u5361\u5167"
+    ],
+    "name:zul_x_preferred":[
+        "Letlhakane"
     ],
     "qs:gn_country":"BW",
     "qs:gn_fcode":"PPL",
@@ -132,7 +159,7 @@
         }
     ],
     "wof:id":421199013,
-    "wof:lastmodified":1566630223,
+    "wof:lastmodified":1690863629,
     "wof:name":"Letlhakane",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/421/199/015/421199015.geojson
+++ b/data/421/199/015/421199015.geojson
@@ -23,6 +23,12 @@
     "name:ara_x_preferred":[
         "\u0645\u0627\u0647\u0627\u0644\u0627\u0628\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u0647\u0627\u0644\u0627\u0628\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Mahalapye"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0627\u0647\u0627\u0644\u0627\u067e\u06cc\u0647"
     ],
@@ -30,7 +36,8 @@
         "\u0413\u043e\u0440\u0430\u0434 \u041c\u0430\u0445\u0430\u043b\u0430\u043f'\u0435"
     ],
     "name:bel_x_variant":[
-        "\u0413\u043e\u0440\u0430\u0434 \u041c\u0430\u0445\u0430\u043b\u0430\u043f\u0435"
+        "\u0413\u043e\u0440\u0430\u0434 \u041c\u0430\u0445\u0430\u043b\u0430\u043f\u0435",
+        "\u041c\u0430\u0445\u0430\u043b\u0430\u043f\u2019\u0435"
     ],
     "name:ben_x_preferred":[
         "\u09ae\u09be\u09b9\u09be\u09b2\u09be\u09aa\u09c7"
@@ -128,6 +135,9 @@
     "name:tur_x_preferred":[
         "Mahalapye"
     ],
+    "name:ukr_x_preferred":[
+        "\u041c\u0430\u0445\u0430\u043b\u0430\u043f'\u0454"
+    ],
     "name:und_x_variant":[
         "Mahalatswe"
     ],
@@ -139,6 +149,9 @@
     ],
     "name:zho_x_preferred":[
         "\u99ac\u54c8\u62c9\u4f69"
+    ],
+    "name:zul_x_preferred":[
+        "Mahalapye"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Botswana",
@@ -282,7 +295,7 @@
         }
     ],
     "wof:id":421199015,
-    "wof:lastmodified":1636495625,
+    "wof:lastmodified":1690863629,
     "wof:name":"Mahalapye",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/421/199/593/421199593.geojson
+++ b/data/421/199/593/421199593.geojson
@@ -23,6 +23,12 @@
     "name:ara_x_preferred":[
         "\u0628\u0627\u0644\u0627\u0628\u064a\u0647"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u0644\u0627\u0628\u064a\u0647"
+    ],
+    "name:ast_x_preferred":[
+        "Palapye"
+    ],
     "name:azb_x_preferred":[
         "\u067e\u0627\u0644\u0627\u067e\u06cc"
     ],
@@ -124,6 +130,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5e15\u62c9\u4f69"
+    ],
+    "name:zul_x_preferred":[
+        "Palapye"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Botswana",
@@ -266,7 +275,7 @@
         }
     ],
     "wof:id":421199593,
-    "wof:lastmodified":1636495625,
+    "wof:lastmodified":1690863628,
     "wof:name":"Palapye",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/421/201/957/421201957.geojson
+++ b/data/421/201/957/421201957.geojson
@@ -23,6 +23,12 @@
     "name:ara_x_preferred":[
         "\u0633\u064a\u0631\u0648\u0648\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u064a\u0631\u0648\u0648\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Serowe"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u0631\u0648\u0648\u0647"
     ],
@@ -182,6 +188,9 @@
     "name:zho_x_preferred":[
         "\u585e\u7f57\u97e6"
     ],
+    "name:zul_x_preferred":[
+        "Serowe"
+    ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Botswana",
     "ne:ADM0_A3":"BWA",
@@ -322,7 +331,7 @@
         }
     ],
     "wof:id":421201957,
-    "wof:lastmodified":1636495625,
+    "wof:lastmodified":1690863630,
     "wof:name":"Serowe",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/421/203/039/421203039.geojson
+++ b/data/421/203/039/421203039.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_preferred":[
         "\u063a\u0627\u0646\u0632\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0627\u0646\u0632\u0649"
+    ],
     "name:ast_x_preferred":[
         "Ciud\u00e1 de Ghanzi"
     ],
@@ -32,8 +35,17 @@
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0413\u0430\u043d\u0437\u0456"
     ],
+    "name:bel_x_variant":[
+        "\u0413\u0430\u043d\u0437\u0456"
+    ],
     "name:ben_x_preferred":[
         "\u0998\u09be\u09a8\u099c\u09bf"
+    ],
+    "name:cat_x_preferred":[
+        "Ghanzi"
+    ],
+    "name:ceb_x_preferred":[
+        "Ghanzi"
     ],
     "name:ces_x_preferred":[
         "Ghanzi"
@@ -125,6 +137,9 @@
     "name:por_x_preferred":[
         "Ghanzi"
     ],
+    "name:pus_x_preferred":[
+        "\u06ab\u0647\u0627\u0646\u0632\u064a(\u0628\u0648\u062a\u0633\u0648\u0627\u0646\u0627)"
+    ],
     "name:ron_x_preferred":[
         "Ghanzi"
     ],
@@ -172,6 +187,9 @@
     ],
     "name:zho_x_preferred":[
         "\u676d\u6fdf"
+    ],
+    "name:zul_x_preferred":[
+        "Ghanzi"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Botswana",
@@ -314,7 +332,7 @@
         }
     ],
     "wof:id":421203039,
-    "wof:lastmodified":1566630219,
+    "wof:lastmodified":1690863624,
     "wof:name":"Khanzi",
     "wof:parent_id":85669589,
     "wof:placetype":"locality",

--- a/data/856/322/35/85632235.geojson
+++ b/data/856/322/35/85632235.geojson
@@ -28,6 +28,9 @@
     "mz:is_current":1,
     "mz:max_zoom":9.0,
     "mz:min_zoom":4.0,
+    "name:abk_x_preferred":[
+        "\u0411\u043e\u0442\u0441\u0432\u0430\u043d\u0430"
+    ],
     "name:ace_x_preferred":[
         "Botswana"
     ],
@@ -46,11 +49,17 @@
     "name:amh_x_preferred":[
         "\u1266\u1275\u1235\u12cb\u1293"
     ],
+    "name:ami_x_preferred":[
+        "Botswana"
+    ],
     "name:ang_x_preferred":[
         "Botswana"
     ],
     "name:ang_x_variant":[
         "Bots\u01bfana"
+    ],
+    "name:anp_x_preferred":[
+        "\u092c\u094b\u0924\u094d\u0938\u094d\u0935\u093e\u0928\u093e"
     ],
     "name:ara_x_preferred":[
         "\u0628\u0648\u062a\u0633\u0648\u0627\u0646\u0627"
@@ -70,11 +79,17 @@
     "name:arz_x_preferred":[
         "\u0628\u0648\u062a\u0633\u0648\u0627\u0646\u0627"
     ],
+    "name:asm_x_preferred":[
+        "\u09ac\u09ce\u099a\u09cb\u09f1\u09be\u09a8\u09be"
+    ],
     "name:ast_x_preferred":[
         "Botswana"
     ],
     "name:ast_x_variant":[
         "Botsuana"
+    ],
+    "name:avk_x_preferred":[
+        "Botswana"
     ],
     "name:aym_x_preferred":[
         "Butswana"
@@ -97,6 +112,9 @@
     "name:ban_x_preferred":[
         "Botswana"
     ],
+    "name:bar_x_preferred":[
+        "Botswana"
+    ],
     "name:bcl_x_preferred":[
         "Botswana"
     ],
@@ -114,6 +132,9 @@
     ],
     "name:bho_x_preferred":[
         "\u092c\u094b\u0924\u094d\u0938\u0935\u093e\u0928\u093e"
+    ],
+    "name:bis_x_preferred":[
+        "Botsuana"
     ],
     "name:bjn_x_preferred":[
         "Botswana"
@@ -172,10 +193,16 @@
     "name:cor_x_preferred":[
         "Botswana"
     ],
+    "name:cos_x_preferred":[
+        "Botazuana"
+    ],
     "name:crh_x_preferred":[
         "Botsvana"
     ],
     "name:cym_x_preferred":[
+        "Botswana"
+    ],
+    "name:dag_x_preferred":[
         "Botswana"
     ],
     "name:dan_x_preferred":[
@@ -273,7 +300,8 @@
         "Botswana"
     ],
     "name:ful_x_variant":[
-        "Botswaana"
+        "Botswaana",
+        "Boosuwaana"
     ],
     "name:gag_x_preferred":[
         "Botsvana"
@@ -300,6 +328,9 @@
     ],
     "name:glv_x_preferred":[
         "Yn Votswaan"
+    ],
+    "name:gpe_x_preferred":[
+        "Botswana"
     ],
     "name:grn_x_preferred":[
         "Votusuana"
@@ -424,6 +455,9 @@
     "name:kbp_x_preferred":[
         "P\u0254c\u0269waanaa"
     ],
+    "name:kcg_x_preferred":[
+        "Botswana"
+    ],
     "name:khm_x_preferred":[
         "\u1794\u17bb\u178f\u179f\u17d2\u179c\u17b6\u178e\u17b6"
     ],
@@ -453,6 +487,9 @@
     ],
     "name:lao_x_preferred":[
         "\u0e9a\u0ead\u0eb1\u0e94\u0eaa\u0eb0\u0ea7\u0eb2\u0e99\u0eb2"
+    ],
+    "name:lao_x_variant":[
+        "\u0e9b\u0eb0\u0ec0\u0e97\u0e94\u0e9a\u0ead\u0e95\u0eaa\u0eb0\u0ea7\u0eb2\u0e99\u0eb2"
     ],
     "name:lat_x_preferred":[
         "Botswana"
@@ -486,6 +523,9 @@
     ],
     "name:lit_x_preferred":[
         "Botsvana"
+    ],
+    "name:lld_x_preferred":[
+        "Botsuana"
     ],
     "name:lmo_x_preferred":[
         "Botswana"
@@ -523,6 +563,12 @@
     "name:mar_x_variant":[
         "\u092c\u094b\u091f\u094d\u0938\u0935\u093e\u0928\u093e"
     ],
+    "name:mdf_x_preferred":[
+        "\u0411\u043e\u0442\u0441\u0432\u0430\u043d\u0430"
+    ],
+    "name:mhr_x_preferred":[
+        "\u0411\u043e\u0442\u0441\u0432\u0430\u043d\u0435\u0430"
+    ],
     "name:min_x_preferred":[
         "Botswana"
     ],
@@ -534,6 +580,9 @@
     ],
     "name:mlt_x_preferred":[
         "Botswana"
+    ],
+    "name:mni_x_preferred":[
+        "\uabd5\uabe3\uabc7\uabed\uabc1\uabed\uabcb\uabe5\uabc5\uabe5"
     ],
     "name:mon_x_preferred":[
         "\u0411\u043e\u0442\u0441\u0432\u0430\u043d\u0430"
@@ -692,6 +741,9 @@
     "name:san_x_preferred":[
         "\u092c\u094b\u0924\u094d\u0938\u0935\u093e\u0928\u093e"
     ],
+    "name:sat_x_preferred":[
+        "\u1c75\u1c73\u1c5b\u1c65\u1c73\u1c63\u1c5f\u1c71\u1c5f"
+    ],
     "name:scn_x_preferred":[
         "Botsuana"
     ],
@@ -700,6 +752,12 @@
     ],
     "name:sgs_x_preferred":[
         "Botsvana"
+    ],
+    "name:shi_x_preferred":[
+        "Botswana"
+    ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1015\u103d\u1010\u103a\u1089\u101e\u101d\u1083\u1087\u107c\u1083\u1087"
     ],
     "name:sin_x_preferred":[
         "\u0db6\u0ddc\u0dc3\u0dca\u0da7\u0dca\u0dc0\u0dcf\u0db1\u0dcf"
@@ -714,6 +772,12 @@
         "Bocvana"
     ],
     "name:sme_x_preferred":[
+        "Botswana"
+    ],
+    "name:smn_x_preferred":[
+        "Botswana"
+    ],
+    "name:sms_x_preferred":[
         "Botswana"
     ],
     "name:sna_x_preferred":[
@@ -783,6 +847,9 @@
     "name:tat_x_preferred":[
         "\u0411\u043e\u0442\u0441\u0432\u0430\u043d\u0430"
     ],
+    "name:tay_x_preferred":[
+        "Botswana"
+    ],
     "name:tel_x_preferred":[
         "\u0c2c\u0c4b\u0c24\u0c4d\u0c38\u0c41\u0c35\u0c3e\u0c28\u0c3e"
     ],
@@ -804,8 +871,14 @@
     "name:tir_x_preferred":[
         "\u1266\u1275\u1235\u12cb\u1293"
     ],
+    "name:tok_x_preferred":[
+        "ma Posuwana"
+    ],
     "name:ton_x_preferred":[
         "Potisiuana"
+    ],
+    "name:trv_x_preferred":[
+        "Botswana"
     ],
     "name:tsn_x_preferred":[
         "Botswana"
@@ -816,11 +889,17 @@
     "name:tuk_x_preferred":[
         "Botswana"
     ],
+    "name:tum_x_preferred":[
+        "Botswana"
+    ],
     "name:tur_x_preferred":[
         "Botsvana"
     ],
     "name:tur_x_variant":[
         "Botsvana Cumhuriyeti",
+        "Botswana"
+    ],
+    "name:twi_x_preferred":[
         "Botswana"
     ],
     "name:udm_x_preferred":[
@@ -881,6 +960,9 @@
     ],
     "name:xal_x_preferred":[
         "\u0411\u043e\u0442\u0441\u0432\u0430\u043c\u0443\u0434\u0438\u043d \u041e\u0440\u043d"
+    ],
+    "name:xho_x_preferred":[
+        "IBotswana"
     ],
     "name:xmf_x_preferred":[
         "\u10d1\u10dd\u10e2\u10e1\u10d5\u10d0\u10dc\u10d0"
@@ -1142,7 +1224,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1617827403,
+    "wof:lastmodified":1690863618,
     "wof:name":"Botswana",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/695/89/85669589.geojson
+++ b/data/856/695/89/85669589.geojson
@@ -74,8 +74,17 @@
     "name:eng_x_variant":[
         "Ghanzi District"
     ],
+    "name:epo_x_preferred":[
+        "Distrikto Ghanzi"
+    ],
     "name:eus_x_preferred":[
         "Ghanzi"
+    ],
+    "name:fao_x_preferred":[
+        "Ghanzi District"
+    ],
+    "name:fas_x_preferred":[
+        "\u0645\u0646\u0637\u0642\u0647 \u0642\u0627\u0646\u0632\u06cc"
     ],
     "name:fin_x_preferred":[
         "Ghanzi"
@@ -118,6 +127,9 @@
     ],
     "name:kor_x_preferred":[
         "\uac04\uc9c0 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\uac04\uc9c0\uad6c"
     ],
     "name:lav_x_preferred":[
         "Ganzi distrikts"
@@ -170,6 +182,9 @@
     "name:tam_x_preferred":[
         "\u0b95\u0ba3\u0bcd\u0b9c\u0bbf  \u0bae\u0bbe\u0bb5\u0b9f\u0bcd\u0b9f\u0bae\u0bcd"
     ],
+    "name:tam_x_variant":[
+        "\u0b95\u0ba3\u0bcd\u0b9c\u0bbf \u0bae\u0bbe\u0bb5\u0b9f\u0bcd\u0b9f\u0bae\u0bcd"
+    ],
     "name:tel_x_preferred":[
         "\u0c18\u0c3e\u0c02\u0c1c\u0c3f \u0c1c\u0c3f\u0c32\u0c4d\u0c32\u0c3e"
     ],
@@ -194,8 +209,14 @@
     "name:vie_x_preferred":[
         "Qu\u1eadn Ghanzi"
     ],
+    "name:wuu_x_preferred":[
+        "\u676d\u6d4e\u533a"
+    ],
     "name:zho_x_preferred":[
         "\u676d\u6fdf\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Ghanzi District"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"BWA",
@@ -318,7 +339,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1636495621,
+    "wof:lastmodified":1690863616,
     "wof:name":"Ghanzi",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/695/93/85669593.geojson
+++ b/data/856/695/93/85669593.geojson
@@ -74,6 +74,9 @@
     "name:eus_x_preferred":[
         "Kgalagadi"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0646\u0637\u0642\u0647 \u06a9\u06af\u0627\u0644\u0627\u06af\u0627\u062f\u06cc"
+    ],
     "name:fin_x_preferred":[
         "Kgalagadi"
     ],
@@ -92,11 +95,17 @@
     "name:heb_x_preferred":[
         "\u05e7\u05d2\u05dc\u05d2\u05d0\u05d3\u05d9"
     ],
+    "name:heb_x_variant":[
+        "\u05e7\u05d2\u05d0\u05dc\u05d2\u05d0\u05d3\u05d9"
+    ],
     "name:hin_x_preferred":[
         "\u0915\u0917\u093e\u0932\u0917\u093e\u0921\u093c\u0940 \u091c\u093f\u0932\u093e"
     ],
     "name:hun_x_preferred":[
         "Kgalagadi"
+    ],
+    "name:hye_x_preferred":[
+        "\u053f\u0563\u0561\u056c\u0561\u0563\u0561\u0564\u056b"
     ],
     "name:ind_x_preferred":[
         "Distrik Kgalagadi"
@@ -115,6 +124,9 @@
     ],
     "name:kor_x_preferred":[
         "\ud06c\uac08\ub77c\uac00\ub514 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ud06c\uac08\ub77c\uac00\ub514\uad6c"
     ],
     "name:lav_x_preferred":[
         "Khalahadi distrikts"
@@ -191,8 +203,14 @@
     "name:vie_x_preferred":[
         "Qu\u1eadn Kgalagadi"
     ],
+    "name:wuu_x_preferred":[
+        "\u5361\u62c9\u54c8\u8fea\u533a"
+    ],
     "name:zho_x_preferred":[
         "\u5361\u62c9\u54c8\u8fea\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Kgalagadi District"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"BWA",
@@ -315,7 +333,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1636495621,
+    "wof:lastmodified":1690863616,
     "wof:name":"Kgalagadi",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/695/99/85669599.geojson
+++ b/data/856/695/99/85669599.geojson
@@ -80,11 +80,17 @@
     "name:fra_x_preferred":[
         "District du Nord-Ouest"
     ],
+    "name:frr_x_preferred":[
+        "North-West"
+    ],
     "name:guj_x_preferred":[
         "\u0a89\u0aa4\u0acd\u0aa4\u0ab0-\u0aaa\u0ab6\u0acd\u0a9a\u0abf\u0aae \u0a9c\u0abf\u0ab2\u0acd\u0ab2\u0acb"
     ],
     "name:heb_x_preferred":[
         "\u05e6\u05e4\u05d5\u05df \u05de\u05e2\u05e8\u05d1"
+    ],
+    "name:heb_x_variant":[
+        "\u05e0\u05d2\u05d0\u05de\u05d9\u05dc\u05e0\u05d3"
     ],
     "name:hin_x_preferred":[
         "\u0909\u0924\u094d\u0924\u0930-\u092a\u0936\u094d\u091a\u093f\u092e\u0940 \u091c\u093f\u0932\u093e"
@@ -109,6 +115,9 @@
     ],
     "name:kor_x_preferred":[
         "\ubd81\uc11c\ubd80 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ubd81\uc11c\ubd80\uad6c"
     ],
     "name:lav_x_preferred":[
         "Zieme\u013crietumu distrikts"
@@ -176,8 +185,14 @@
     "name:vie_x_preferred":[
         "Qu\u1eadn T\u00e2y-B\u1eafc"
     ],
+    "name:wuu_x_preferred":[
+        "\u897f\u5317\u533a"
+    ],
     "name:zho_x_preferred":[
         "\u897f\u5317\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "North-West District"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"BWA",
@@ -300,7 +315,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1636495622,
+    "wof:lastmodified":1690863617,
     "wof:name":"North-West",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/696/01/85669601.geojson
+++ b/data/856/696/01/85669601.geojson
@@ -83,6 +83,9 @@
     "name:fas_x_preferred":[
         "\u0645\u0631\u06a9\u0632\u06cc"
     ],
+    "name:fas_x_variant":[
+        "\u0628\u062e\u0634 \u0645\u0631\u06a9\u0632\u06cc"
+    ],
     "name:fin_x_preferred":[
         "Central District"
     ],
@@ -103,6 +106,9 @@
     ],
     "name:hun_x_preferred":[
         "K\u00f6z\u00e9p"
+    ],
+    "name:hye_x_preferred":[
+        "\u053f\u0565\u0576\u057f\u0580\u0578\u0576\u0561\u056f\u0561\u0576 \u0577\u0580\u057b\u0561\u0576"
     ],
     "name:ind_x_preferred":[
         "Distrik Central"
@@ -126,7 +132,8 @@
         "\uc13c\ud2b8\ub7f4"
     ],
     "name:kor_x_variant":[
-        "\uc911\ubd80 \uad6c"
+        "\uc911\ubd80 \uad6c",
+        "\uc911\ubd80\uad6c"
     ],
     "name:lav_x_preferred":[
         "Centr\u0101lais distrikts"
@@ -203,11 +210,17 @@
     "name:vie_x_preferred":[
         "Qu\u1eadn Mi\u1ec1n Trung"
     ],
+    "name:wuu_x_preferred":[
+        "\u4e2d\u90e8\u533a"
+    ],
     "name:zho_x_preferred":[
         "\u4e2d\u90e8"
     ],
     "name:zho_x_variant":[
         "\u4e2d\u90e8\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Central District"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"BWA",
@@ -328,7 +341,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1636495623,
+    "wof:lastmodified":1690863621,
     "wof:name":"Central",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/696/07/85669607.geojson
+++ b/data/856/696/07/85669607.geojson
@@ -101,6 +101,9 @@
     "name:hun_x_preferred":[
         "Kgatleng"
     ],
+    "name:hye_x_preferred":[
+        "\u053f\u0563\u0561\u057f\u056c\u0565\u0576\u0563"
+    ],
     "name:ind_x_preferred":[
         "Distrik Kgatleng"
     ],
@@ -118,6 +121,9 @@
     ],
     "name:kor_x_preferred":[
         "\ud06c\uac00\ud2c0\ub81d \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ud06c\uac00\ud2c0\ub81d\uad6c"
     ],
     "name:lav_x_preferred":[
         "Khatlenas distrikts"
@@ -191,8 +197,14 @@
     "name:vie_x_preferred":[
         "Qu\u1eadn Kgatleng"
     ],
+    "name:wuu_x_preferred":[
+        "\u5361\u7279\u4f26\u533a"
+    ],
     "name:zho_x_preferred":[
         "\u5361\u7279\u502b\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Kgatleng District"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"BWA",
@@ -315,7 +327,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1636495623,
+    "wof:lastmodified":1690863620,
     "wof:name":"Kgatleng",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/696/11/85669611.geojson
+++ b/data/856/696/11/85669611.geojson
@@ -77,6 +77,9 @@
     "name:eus_x_preferred":[
         "Kweneng"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0646\u0637\u0642\u0647 \u06a9\u0648\u0626\u0646\u0646\u06af"
+    ],
     "name:fin_x_preferred":[
         "Kweneng"
     ],
@@ -118,6 +121,9 @@
     ],
     "name:kor_x_preferred":[
         "\ud018\ub139 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ud018\ub139\uad6c"
     ],
     "name:lav_x_preferred":[
         "Kvenenas distrikts"
@@ -176,6 +182,9 @@
     "name:tha_x_preferred":[
         "\u0e40\u0e02\u0e15\u0e04\u0e40\u0e27\u0e40\u0e19\u0e07"
     ],
+    "name:tsn_x_preferred":[
+        "Kweneng District"
+    ],
     "name:tur_x_preferred":[
         "Kweneng B\u00f6lgesi"
     ],
@@ -191,8 +200,14 @@
     "name:vie_x_preferred":[
         "Qu\u1eadn Kweneng"
     ],
+    "name:wuu_x_preferred":[
+        "\u594e\u5ae9\u533a"
+    ],
     "name:zho_x_preferred":[
         "\u594e\u5ae9\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Kweneng District"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"BWA",
@@ -315,7 +330,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1636495622,
+    "wof:lastmodified":1690863619,
     "wof:name":"Kweneng",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/696/15/85669615.geojson
+++ b/data/856/696/15/85669615.geojson
@@ -87,6 +87,9 @@
     "name:fra_x_variant":[
         "District du Sud-Est"
     ],
+    "name:frr_x_preferred":[
+        "South-East"
+    ],
     "name:guj_x_preferred":[
         "\u0aa6\u0a95\u0acd\u0ab7\u0abf\u0aa3-\u0aaa\u0ac2\u0ab0\u0acd\u0ab5 \u0a9c\u0abf\u0ab2\u0acd\u0ab2\u0acb"
     ],
@@ -116,6 +119,9 @@
     ],
     "name:kor_x_preferred":[
         "\ub0a8\ub3d9\ubd80 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ub0a8\ub3d9\ubd80\uad6c"
     ],
     "name:lav_x_preferred":[
         "Dienvidaustrumu distrikts"
@@ -180,8 +186,14 @@
     "name:vie_x_preferred":[
         "Qu\u1eadn \u0110\u00f4ng-Nam"
     ],
+    "name:wuu_x_preferred":[
+        "\u4e1c\u5357\u533a"
+    ],
     "name:zho_x_preferred":[
         "\u6771\u5357\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "South-East District"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"BWA",
@@ -302,7 +314,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1636495623,
+    "wof:lastmodified":1690863621,
     "wof:name":"South-East",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/696/19/85669619.geojson
+++ b/data/856/696/19/85669619.geojson
@@ -41,6 +41,9 @@
     "name:aze_x_preferred":[
         "C\u0259nubi dair\u0259"
     ],
+    "name:aze_x_variant":[
+        "C\u0259nub b\u00f6lg\u0259si"
+    ],
     "name:bel_x_preferred":[
         "\u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0430\u043a\u0440\u0443\u0433\u0430"
     ],
@@ -82,6 +85,9 @@
     "name:eus_x_preferred":[
         "Hegoaldea"
     ],
+    "name:fas_x_preferred":[
+        "\u0628\u062e\u0634 \u062c\u0646\u0648\u0628\u06cc"
+    ],
     "name:fin_x_preferred":[
         "Southern District"
     ],
@@ -114,6 +120,9 @@
     ],
     "name:kor_x_preferred":[
         "\ub0a8\ubd80 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ub0a8\ubd80\uad6c"
     ],
     "name:lav_x_preferred":[
         "Dienvidu distrikts"
@@ -190,6 +199,9 @@
     "name:vie_x_variant":[
         "Qu\u1eadn Mi\u1ec1n Nam"
     ],
+    "name:wuu_x_preferred":[
+        "\u5357\u90e8\u533a"
+    ],
     "name:zho_cn_x_preferred":[
         "\u5357\u533a"
     ],
@@ -198,6 +210,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5357\u90e8\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Southern District"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"BWA",
@@ -318,7 +333,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1636495622,
+    "wof:lastmodified":1690863620,
     "wof:name":"Southern",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/696/27/85669627.geojson
+++ b/data/856/696/27/85669627.geojson
@@ -41,6 +41,9 @@
     "name:bel_x_preferred":[
         "\u041f\u0430\u045e\u043d\u043e\u0447\u043d\u0430-\u0443\u0441\u0445\u043e\u0434\u043d\u044f\u044f \u0430\u043a\u0440\u0443\u0433\u0430"
     ],
+    "name:bel_x_variant":[
+        "\u041f\u0430\u045e\u043d\u043e\u0447\u043d\u0430-\u045e\u0441\u0445\u043e\u0434\u043d\u044f\u044f \u0430\u043a\u0440\u0443\u0433\u0430"
+    ],
     "name:ben_x_preferred":[
         "\u09a8\u09b0\u09cd\u09a5-\u0987\u09b8\u09cd\u099f \u099c\u09c7\u09b2\u09be"
     ],
@@ -110,6 +113,9 @@
     "name:kor_x_preferred":[
         "\ubd81\ub3d9\ubd80 \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\ubd81\ub3d9\ubd80\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Zieme\u013caustrumu distrikts"
     ],
@@ -176,8 +182,14 @@
     "name:vie_x_preferred":[
         "Qu\u1eadn \u0110\u00f4ng-B\u1eafc"
     ],
+    "name:wuu_x_preferred":[
+        "\u4e1c\u5317\u533a"
+    ],
     "name:zho_x_preferred":[
         "\u6771\u5317\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "North-East District"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"BWA",
@@ -298,7 +310,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1636495622,
+    "wof:lastmodified":1690863619,
     "wof:name":"North-East",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/696/31/85669631.geojson
+++ b/data/856/696/31/85669631.geojson
@@ -82,6 +82,9 @@
     "name:fra_x_preferred":[
         "District du Sud-Est"
     ],
+    "name:frr_x_preferred":[
+        "South-East"
+    ],
     "name:guj_x_preferred":[
         "\u0aa6\u0a95\u0acd\u0ab7\u0abf\u0aa3-\u0aaa\u0ac2\u0ab0\u0acd\u0ab5 \u0a9c\u0abf\u0ab2\u0acd\u0ab2\u0acb"
     ],
@@ -105,6 +108,9 @@
     ],
     "name:kor_x_preferred":[
         "\ub0a8\ub3d9\ubd80 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ub0a8\ub3d9\ubd80\uad6c"
     ],
     "name:lav_x_preferred":[
         "Dienvidaustrumu distrikts"
@@ -169,8 +175,14 @@
     "name:vie_x_preferred":[
         "Qu\u1eadn \u0110\u00f4ng-Nam"
     ],
+    "name:wuu_x_preferred":[
+        "\u4e1c\u5357\u533a"
+    ],
     "name:zho_x_preferred":[
         "\u6771\u5357\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "South-East District"
     ],
     "qs:a0":"Botswana",
     "qs:a0_lc":"BW",
@@ -236,7 +248,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1607390901,
+    "wof:lastmodified":1690863620,
     "wof:name":"Gaborone",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/696/35/85669635.geojson
+++ b/data/856/696/35/85669635.geojson
@@ -40,6 +40,9 @@
     "name:bel_x_preferred":[
         "\u041f\u0430\u045e\u043d\u043e\u0447\u043d\u0430-\u0443\u0441\u0445\u043e\u0434\u043d\u044f\u044f \u0430\u043a\u0440\u0443\u0433\u0430"
     ],
+    "name:bel_x_variant":[
+        "\u041f\u0430\u045e\u043d\u043e\u0447\u043d\u0430-\u045e\u0441\u0445\u043e\u0434\u043d\u044f\u044f \u0430\u043a\u0440\u0443\u0433\u0430"
+    ],
     "name:ben_x_preferred":[
         "\u09a8\u09b0\u09cd\u09a5-\u0987\u09b8\u09cd\u099f \u099c\u09c7\u09b2\u09be"
     ],
@@ -106,6 +109,9 @@
     "name:kor_x_preferred":[
         "\ubd81\ub3d9\ubd80 \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\ubd81\ub3d9\ubd80\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Zieme\u013caustrumu distrikts"
     ],
@@ -169,8 +175,14 @@
     "name:vie_x_preferred":[
         "Qu\u1eadn \u0110\u00f4ng-B\u1eafc"
     ],
+    "name:wuu_x_preferred":[
+        "\u4e1c\u5317\u533a"
+    ],
     "name:zho_x_preferred":[
         "\u6771\u5317\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "North-East District"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"BWA",
@@ -292,7 +304,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1636495622,
+    "wof:lastmodified":1690863619,
     "wof:name":"Francistown",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/696/39/85669639.geojson
+++ b/data/856/696/39/85669639.geojson
@@ -109,6 +109,9 @@
     "name:fra_x_variant":[
         "District du Sud-Est"
     ],
+    "name:frr_x_preferred":[
+        "South-East"
+    ],
     "name:guj_x_preferred":[
         "\u0aa6\u0a95\u0acd\u0ab7\u0abf\u0aa3-\u0aaa\u0ac2\u0ab0\u0acd\u0ab5 \u0a9c\u0abf\u0ab2\u0acd\u0ab2\u0acb"
     ],
@@ -149,7 +152,8 @@
         "\ub85c\ubc14\uccb4"
     ],
     "name:kor_x_variant":[
-        "\ub0a8\ub3d9\ubd80 \uad6c"
+        "\ub0a8\ub3d9\ubd80 \uad6c",
+        "\ub0a8\ub3d9\ubd80\uad6c"
     ],
     "name:lav_x_preferred":[
         "Dienvidaustrumu distrikts"
@@ -241,11 +245,17 @@
     "name:vie_x_preferred":[
         "Qu\u1eadn \u0110\u00f4ng-Nam"
     ],
+    "name:wuu_x_preferred":[
+        "\u4e1c\u5357\u533a"
+    ],
     "name:zho_x_preferred":[
         "\u6d1b\u5df4\u7b56"
     ],
     "name:zho_x_variant":[
         "\u6771\u5357\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "South-East District"
     ],
     "qs:a0":"Botswana",
     "qs:a0_lc":"BW",
@@ -313,7 +323,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1636495623,
+    "wof:lastmodified":1690863621,
     "wof:name":"Lobatse",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/696/45/85669645.geojson
+++ b/data/856/696/45/85669645.geojson
@@ -79,6 +79,9 @@
     "name:eus_x_preferred":[
         "Erdialdea"
     ],
+    "name:fas_x_preferred":[
+        "\u0628\u062e\u0634 \u0645\u0631\u06a9\u0632\u06cc"
+    ],
     "name:fin_x_preferred":[
         "Central District"
     ],
@@ -99,6 +102,9 @@
     ],
     "name:hun_x_preferred":[
         "Selebi-Phikwe"
+    ],
+    "name:hye_x_preferred":[
+        "\u053f\u0565\u0576\u057f\u0580\u0578\u0576\u0561\u056f\u0561\u0576 \u0577\u0580\u057b\u0561\u0576"
     ],
     "name:ind_x_preferred":[
         "Distrik Central"
@@ -122,7 +128,8 @@
         "\uc13c\ud2b8\ub7f4"
     ],
     "name:kor_x_variant":[
-        "\uc911\ubd80 \uad6c"
+        "\uc911\ubd80 \uad6c",
+        "\uc911\ubd80\uad6c"
     ],
     "name:lav_x_preferred":[
         "Centr\u0101lais distrikts"
@@ -196,11 +203,17 @@
     "name:vie_x_preferred":[
         "Qu\u1eadn Mi\u1ec1n Trung"
     ],
+    "name:wuu_x_preferred":[
+        "\u4e2d\u90e8\u533a"
+    ],
     "name:zho_x_preferred":[
         "\u4e2d\u90e8"
     ],
     "name:zho_x_variant":[
         "\u4e2d\u90e8\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Central District"
     ],
     "qs:a0":"Botswana",
     "qs:a0_lc":"BW",
@@ -261,7 +274,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1636495622,
+    "wof:lastmodified":1690863619,
     "wof:name":"Selebi-Phikwe",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/696/49/85669649.geojson
+++ b/data/856/696/49/85669649.geojson
@@ -82,6 +82,9 @@
     "name:fas_x_preferred":[
         "\u0633\u0648\u0648\u0627"
     ],
+    "name:fas_x_variant":[
+        "\u0628\u062e\u0634 \u0645\u0631\u06a9\u0632\u06cc"
+    ],
     "name:fin_x_preferred":[
         "Central District"
     ],
@@ -102,6 +105,9 @@
     ],
     "name:hun_x_preferred":[
         "Sowa"
+    ],
+    "name:hye_x_preferred":[
+        "\u053f\u0565\u0576\u057f\u0580\u0578\u0576\u0561\u056f\u0561\u0576 \u0577\u0580\u057b\u0561\u0576"
     ],
     "name:ind_x_preferred":[
         "Distrik Central"
@@ -125,7 +131,8 @@
         "\uc13c\ud2b8\ub7f4"
     ],
     "name:kor_x_variant":[
-        "\uc911\ubd80 \uad6c"
+        "\uc911\ubd80 \uad6c",
+        "\uc911\ubd80\uad6c"
     ],
     "name:lav_x_preferred":[
         "Centr\u0101lais distrikts"
@@ -199,6 +206,9 @@
     "name:vie_x_preferred":[
         "Qu\u1eadn Mi\u1ec1n Trung"
     ],
+    "name:wuu_x_preferred":[
+        "\u4e2d\u90e8\u533a"
+    ],
     "name:zho_cn_x_preferred":[
         "\u7d22\u74e6"
     ],
@@ -210,6 +220,9 @@
     ],
     "name:zho_x_variant":[
         "\u4e2d\u90e8\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Central District"
     ],
     "qs:a0":"Botswana",
     "qs:a0_lc":"BW",
@@ -271,7 +284,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1636495623,
+    "wof:lastmodified":1690863622,
     "wof:name":"Sowa",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/696/53/85669653.geojson
+++ b/data/856/696/53/85669653.geojson
@@ -40,6 +40,9 @@
     "name:aze_x_preferred":[
         "C\u0259nubi dair\u0259"
     ],
+    "name:aze_x_variant":[
+        "C\u0259nub b\u00f6lg\u0259si"
+    ],
     "name:bel_x_preferred":[
         "\u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430\u044f \u0430\u043a\u0440\u0443\u0433\u0430"
     ],
@@ -79,6 +82,9 @@
     "name:eus_x_preferred":[
         "Hegoaldea"
     ],
+    "name:fas_x_preferred":[
+        "\u0628\u062e\u0634 \u062c\u0646\u0648\u0628\u06cc"
+    ],
     "name:fin_x_preferred":[
         "Southern District"
     ],
@@ -117,6 +123,9 @@
     ],
     "name:kor_x_preferred":[
         "\ub0a8\ubd80 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ub0a8\ubd80\uad6c"
     ],
     "name:lav_x_preferred":[
         "Dienvidu distrikts"
@@ -187,8 +196,14 @@
     "name:vie_x_preferred":[
         "Qu\u1eadn Mi\u1ec1n Nam"
     ],
+    "name:wuu_x_preferred":[
+        "\u5357\u90e8\u533a"
+    ],
     "name:zho_x_preferred":[
         "\u5357\u90e8\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Southern District"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"BWA",
@@ -310,7 +325,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1636495623,
+    "wof:lastmodified":1690863621,
     "wof:name":"Jwaneng",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/890/415/449/890415449.geojson
+++ b/data/890/415/449/890415449.geojson
@@ -79,6 +79,9 @@
     "name:pol_x_preferred":[
         "Nokaneng"
     ],
+    "name:por_x_preferred":[
+        "Nokaneng"
+    ],
     "name:rus_x_preferred":[
         "\u041d\u043e\u043a\u0430\u043d\u0435\u043d\u0433"
     ],
@@ -114,6 +117,9 @@
     ],
     "name:zho_tw_x_preferred":[
         "\u8afe\u5361\u80fd"
+    ],
+    "name:zul_x_preferred":[
+        "Nokaneng"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Botswana",
@@ -240,7 +246,7 @@
         }
     ],
     "wof:id":890415449,
-    "wof:lastmodified":1636495626,
+    "wof:lastmodified":1690863633,
     "wof:name":"Nokaneng",
     "wof:parent_id":85669599,
     "wof:placetype":"locality",

--- a/data/890/415/451/890415451.geojson
+++ b/data/890/415/451/890415451.geojson
@@ -79,6 +79,9 @@
     "name:pol_x_preferred":[
         "Mopipi"
     ],
+    "name:por_x_preferred":[
+        "Mopipi"
+    ],
     "name:rus_x_preferred":[
         "\u041c\u043e\u043f\u0438\u043f\u0438"
     ],
@@ -111,6 +114,9 @@
     ],
     "name:zho_tw_x_preferred":[
         "\u83ab\u76ae\u76ae"
+    ],
+    "name:zul_x_preferred":[
+        "Mopipi"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Botswana",
@@ -237,7 +243,7 @@
         }
     ],
     "wof:id":890415451,
-    "wof:lastmodified":1636495626,
+    "wof:lastmodified":1690863633,
     "wof:name":"Mopipi",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/890/420/083/890420083.geojson
+++ b/data/890/420/083/890420083.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Dumadumana"
     ],
+    "name:deu_x_preferred":[
+        "Dumadumana"
+    ],
     "name:eng_x_preferred":[
         "Dumadumana"
     ],
@@ -35,6 +38,9 @@
         "Dumadumana"
     ],
     "name:tsn_x_preferred":[
+        "Dumadumana"
+    ],
+    "name:uzb_x_preferred":[
         "Dumadumana"
     ],
     "qs:name":"Dumadumana",
@@ -70,7 +76,7 @@
         }
     ],
     "wof:id":890420083,
-    "wof:lastmodified":1566630232,
+    "wof:lastmodified":1690863640,
     "wof:name":"Dumadumana",
     "wof:parent_id":85669631,
     "wof:placetype":"locality",

--- a/data/890/430/573/890430573.geojson
+++ b/data/890/430/573/890430573.geojson
@@ -25,7 +25,22 @@
     "name:eng_x_preferred":[
         "Malakas"
     ],
+    "name:eng_x_variant":[
+        "Malakia"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30de\u30e9\u30ab\u30b9"
+    ],
     "name:lat_x_preferred":[
+        "Malakas"
+    ],
+    "name:por_x_preferred":[
+        "malakoi"
+    ],
+    "name:rus_x_preferred":[
+        "\u041c\u0430\u043b\u0430\u043a\u0438\u044f"
+    ],
+    "name:tur_x_preferred":[
         "Malakas"
     ],
     "name:und_x_variant":[
@@ -62,7 +77,7 @@
         }
     ],
     "wof:id":890430573,
-    "wof:lastmodified":1566630227,
+    "wof:lastmodified":1690863635,
     "wof:name":"Malaka",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/890/430/575/890430575.geojson
+++ b/data/890/430/575/890430575.geojson
@@ -46,6 +46,9 @@
     "name:pol_x_preferred":[
         "Makalamabedi"
     ],
+    "name:por_x_preferred":[
+        "Makalamabedi"
+    ],
     "name:swa_x_preferred":[
         "Makalamabedi"
     ],
@@ -85,7 +88,7 @@
         }
     ],
     "wof:id":890430575,
-    "wof:lastmodified":1566630227,
+    "wof:lastmodified":1690863634,
     "wof:name":"Makalamabedi",
     "wof:parent_id":85669599,
     "wof:placetype":"locality",

--- a/data/890/430/583/890430583.geojson
+++ b/data/890/430/583/890430583.geojson
@@ -28,6 +28,9 @@
     "name:ceb_x_preferred":[
         "Khuis"
     ],
+    "name:deu_x_preferred":[
+        "Khuis"
+    ],
     "name:eng_x_preferred":[
         "Khuis"
     ],
@@ -46,10 +49,19 @@
     "name:pol_x_preferred":[
         "Khuis"
     ],
+    "name:por_x_preferred":[
+        "Khuis"
+    ],
     "name:swa_x_preferred":[
         "Khuis"
     ],
     "name:swe_x_preferred":[
+        "Khuis"
+    ],
+    "name:tsn_x_preferred":[
+        "Khuis"
+    ],
+    "name:uzb_x_preferred":[
         "Khuis"
     ],
     "qs:name":"Khuis",
@@ -87,7 +99,7 @@
         }
     ],
     "wof:id":890430583,
-    "wof:lastmodified":1566630228,
+    "wof:lastmodified":1690863635,
     "wof:name":"Khuis",
     "wof:parent_id":1108730591,
     "wof:placetype":"locality",

--- a/data/890/430/585/890430585.geojson
+++ b/data/890/430/585/890430585.geojson
@@ -43,10 +43,19 @@
     "name:pol_x_preferred":[
         "Kavimba"
     ],
+    "name:por_x_preferred":[
+        "Kavimba"
+    ],
     "name:swa_x_preferred":[
         "Kavimba"
     ],
     "name:swe_x_preferred":[
+        "Kavimba"
+    ],
+    "name:tsn_x_preferred":[
+        "Kavimba"
+    ],
+    "name:uzb_x_preferred":[
         "Kavimba"
     ],
     "qs:name":"Kavimba",
@@ -84,7 +93,7 @@
         }
     ],
     "wof:id":890430585,
-    "wof:lastmodified":1566630228,
+    "wof:lastmodified":1690863635,
     "wof:name":"Kavimba",
     "wof:parent_id":421199941,
     "wof:placetype":"locality",

--- a/data/890/430/587/890430587.geojson
+++ b/data/890/430/587/890430587.geojson
@@ -46,6 +46,9 @@
     "name:pol_x_preferred":[
         "Kalakamati"
     ],
+    "name:por_x_preferred":[
+        "Kalakamati"
+    ],
     "name:swa_x_preferred":[
         "Kalakamati"
     ],
@@ -86,7 +89,7 @@
         }
     ],
     "wof:id":890430587,
-    "wof:lastmodified":1566630227,
+    "wof:lastmodified":1690863634,
     "wof:name":"Kalakamati",
     "wof:parent_id":85669627,
     "wof:placetype":"locality",

--- a/data/890/430/589/890430589.geojson
+++ b/data/890/430/589/890430589.geojson
@@ -43,6 +43,9 @@
     "name:pol_x_preferred":[
         "Kachikau"
     ],
+    "name:por_x_preferred":[
+        "Kachikau"
+    ],
     "name:swa_x_preferred":[
         "Kachikau"
     ],
@@ -50,6 +53,9 @@
         "Kachikau"
     ],
     "name:tsn_x_preferred":[
+        "Kachikau"
+    ],
+    "name:uzb_x_preferred":[
         "Kachikau"
     ],
     "qs:name":"Kachikau",
@@ -85,7 +91,7 @@
         }
     ],
     "wof:id":890430589,
-    "wof:lastmodified":1566630227,
+    "wof:lastmodified":1690863634,
     "wof:name":"Kachikau",
     "wof:parent_id":85669599,
     "wof:placetype":"locality",

--- a/data/890/431/345/890431345.geojson
+++ b/data/890/431/345/890431345.geojson
@@ -40,10 +40,16 @@
     "name:pol_x_preferred":[
         "Mogapinyana"
     ],
+    "name:por_x_preferred":[
+        "Mogapinyana"
+    ],
     "name:swa_x_preferred":[
         "Mogapinyana"
     ],
     "name:swe_x_preferred":[
+        "Mogapinyana"
+    ],
+    "name:tsn_x_preferred":[
         "Mogapinyana"
     ],
     "qs:name":"Mogapinyana",
@@ -79,7 +85,7 @@
         }
     ],
     "wof:id":890431345,
-    "wof:lastmodified":1566630229,
+    "wof:lastmodified":1690863637,
     "wof:name":"Mogapinyana",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/890/431/347/890431347.geojson
+++ b/data/890/431/347/890431347.geojson
@@ -43,6 +43,9 @@
     "name:pol_x_preferred":[
         "Mogapi"
     ],
+    "name:por_x_preferred":[
+        "Mogapi"
+    ],
     "name:swa_x_preferred":[
         "Mogapi"
     ],
@@ -85,7 +88,7 @@
         }
     ],
     "wof:id":890431347,
-    "wof:lastmodified":1566630229,
+    "wof:lastmodified":1690863637,
     "wof:name":"Mogapi",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/890/431/349/890431349.geojson
+++ b/data/890/431/349/890431349.geojson
@@ -40,6 +40,9 @@
     "name:pol_x_preferred":[
         "Mmathubudukwane"
     ],
+    "name:por_x_preferred":[
+        "Mmathubudukwane"
+    ],
     "name:swa_x_preferred":[
         "Mmathubudukwane"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":890431349,
-    "wof:lastmodified":1566630229,
+    "wof:lastmodified":1690863636,
     "wof:name":"Mmathubudukwane",
     "wof:parent_id":85669607,
     "wof:placetype":"locality",

--- a/data/890/431/955/890431955.geojson
+++ b/data/890/431/955/890431955.geojson
@@ -43,6 +43,9 @@
     "name:pol_x_preferred":[
         "Lokgwabe"
     ],
+    "name:por_x_preferred":[
+        "Lokgwabe"
+    ],
     "name:rus_x_preferred":[
         "\u041b\u043e\u043a\u0433\u0432\u0430\u0431\u0435"
     ],
@@ -53,6 +56,9 @@
         "Lokgwabe"
     ],
     "name:tsn_x_preferred":[
+        "Lokgwabe"
+    ],
+    "name:uzb_x_preferred":[
         "Lokgwabe"
     ],
     "ne:ADM0CAP":0.0,
@@ -176,7 +182,7 @@
         }
     ],
     "wof:id":890431955,
-    "wof:lastmodified":1566630229,
+    "wof:lastmodified":1690863636,
     "wof:name":"Lokwabe",
     "wof:parent_id":85669593,
     "wof:placetype":"locality",

--- a/data/890/432/027/890432027.geojson
+++ b/data/890/432/027/890432027.geojson
@@ -76,6 +76,9 @@
     "name:pol_x_preferred":[
         "Lehututu"
     ],
+    "name:por_x_preferred":[
+        "Lehututu"
+    ],
     "name:rus_x_preferred":[
         "\u041b\u0435\u0445\u0443\u0442\u0443\u0442\u0443"
     ],
@@ -96,6 +99,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0644\u06cc\u06c1\u0648\u0679\u0648"
+    ],
+    "name:uzb_x_preferred":[
+        "Lehututu"
     ],
     "name:vie_x_preferred":[
         "Lehututu"
@@ -231,7 +237,7 @@
         }
     ],
     "wof:id":890432027,
-    "wof:lastmodified":1636495627,
+    "wof:lastmodified":1690863642,
     "wof:name":"Lehututu",
     "wof:parent_id":85669593,
     "wof:placetype":"locality",

--- a/data/890/433/505/890433505.geojson
+++ b/data/890/433/505/890433505.geojson
@@ -49,6 +49,9 @@
     "name:pol_x_preferred":[
         "Sehithwa"
     ],
+    "name:por_x_preferred":[
+        "Sehithwa"
+    ],
     "name:rus_x_preferred":[
         "\u0421\u0435\u0445\u0438\u0442\u0432\u0430"
     ],
@@ -63,6 +66,9 @@
     ],
     "name:und_x_variant":[
         "Sehithwe"
+    ],
+    "name:zul_x_preferred":[
+        "Sehithwa"
     ],
     "qs:name":"Sehithwa",
     "qs:photos_9r":0,
@@ -97,7 +103,7 @@
         }
     ],
     "wof:id":890433505,
-    "wof:lastmodified":1566630232,
+    "wof:lastmodified":1690863640,
     "wof:name":"Sehithwa",
     "wof:parent_id":85669599,
     "wof:placetype":"locality",

--- a/data/890/433/507/890433507.geojson
+++ b/data/890/433/507/890433507.geojson
@@ -43,6 +43,9 @@
     "name:pol_x_preferred":[
         "Ramokgonami"
     ],
+    "name:por_x_preferred":[
+        "Ramokgonami"
+    ],
     "name:swa_x_preferred":[
         "Ramokgonami"
     ],
@@ -51,6 +54,9 @@
     ],
     "name:und_x_variant":[
         "Ramakonami"
+    ],
+    "name:zul_x_preferred":[
+        "Ramokgonami"
     ],
     "qs:name":"Ramokgonami",
     "qs:photos_9r":0,
@@ -81,7 +87,7 @@
         }
     ],
     "wof:id":890433507,
-    "wof:lastmodified":1566630233,
+    "wof:lastmodified":1690863641,
     "wof:name":"Ramokgonami",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/890/433/509/890433509.geojson
+++ b/data/890/433/509/890433509.geojson
@@ -40,6 +40,9 @@
     "name:pol_x_preferred":[
         "Pilane Station"
     ],
+    "name:por_x_preferred":[
+        "Pilane Station"
+    ],
     "name:rus_x_preferred":[
         "\u041f\u0438\u043b\u0430\u043d\u0435"
     ],
@@ -83,7 +86,7 @@
         }
     ],
     "wof:id":890433509,
-    "wof:lastmodified":1566630233,
+    "wof:lastmodified":1690863641,
     "wof:name":"Pilane",
     "wof:parent_id":85669607,
     "wof:placetype":"locality",

--- a/data/890/433/511/890433511.geojson
+++ b/data/890/433/511/890433511.geojson
@@ -22,6 +22,12 @@
     "name:afr_x_preferred":[
         "Orapa"
     ],
+    "name:ara_x_preferred":[
+        "\u0627\u0648\u0631\u0627\u0628\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Orapa"
+    ],
     "name:bul_x_preferred":[
         "\u041e\u0440\u0430\u043f\u0430"
     ],
@@ -58,6 +64,9 @@
     "name:pol_x_preferred":[
         "Orapa"
     ],
+    "name:por_x_preferred":[
+        "Orapa"
+    ],
     "name:ron_x_preferred":[
         "Orapa"
     ],
@@ -73,8 +82,14 @@
     "name:tsn_x_preferred":[
         "Orapa"
     ],
+    "name:ukr_x_preferred":[
+        "\u041e\u0440\u0430\u043f\u0430"
+    ],
     "name:zho_x_preferred":[
         "\u5967\u62c9\u5e15"
+    ],
+    "name:zul_x_preferred":[
+        "Orapa"
     ],
     "qs:name":"Orapa",
     "qs:photos_9r":0,
@@ -109,7 +124,7 @@
         }
     ],
     "wof:id":890433511,
-    "wof:lastmodified":1566630233,
+    "wof:lastmodified":1690863641,
     "wof:name":"Orapa",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/890/433/515/890433515.geojson
+++ b/data/890/433/515/890433515.geojson
@@ -31,6 +31,9 @@
     "name:ita_x_preferred":[
         "Mosetse"
     ],
+    "name:jpn_x_preferred":[
+        "\u30e2\u30bb\u30c4\u30a7"
+    ],
     "name:mlg_x_preferred":[
         "Mosetse"
     ],
@@ -38,6 +41,9 @@
         "Mosetse"
     ],
     "name:pol_x_preferred":[
+        "Mosetse"
+    ],
+    "name:por_x_preferred":[
         "Mosetse"
     ],
     "name:swa_x_preferred":[
@@ -48,6 +54,9 @@
     ],
     "name:tsn_x_preferred":[
         "Motsana wa Mosetse"
+    ],
+    "name:tsn_x_variant":[
+        "Mosetse"
     ],
     "qs:name":"Mosetse",
     "qs:photos_9r":0,
@@ -82,7 +91,7 @@
         }
     ],
     "wof:id":890433515,
-    "wof:lastmodified":1566630233,
+    "wof:lastmodified":1690863641,
     "wof:name":"Mosetse",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/890/433/521/890433521.geojson
+++ b/data/890/433/521/890433521.geojson
@@ -43,6 +43,9 @@
     "name:pol_x_preferred":[
         "Makaleng"
     ],
+    "name:por_x_preferred":[
+        "Makaleng"
+    ],
     "name:swa_x_preferred":[
         "Makaleng"
     ],
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":890433521,
-    "wof:lastmodified":1566630233,
+    "wof:lastmodified":1690863641,
     "wof:name":"Makaleng",
     "wof:parent_id":85669627,
     "wof:placetype":"locality",

--- a/data/890/436/587/890436587.geojson
+++ b/data/890/436/587/890436587.geojson
@@ -46,10 +46,16 @@
     "name:pol_x_preferred":[
         "Toteng"
     ],
+    "name:por_x_preferred":[
+        "Toteng"
+    ],
     "name:swe_x_preferred":[
         "Toteng"
     ],
     "name:tsn_x_preferred":[
+        "Toteng"
+    ],
+    "name:zul_x_preferred":[
         "Toteng"
     ],
     "qs:name":"Toteng",
@@ -85,7 +91,7 @@
         }
     ],
     "wof:id":890436587,
-    "wof:lastmodified":1566630229,
+    "wof:lastmodified":1690863636,
     "wof:name":"Toteng",
     "wof:parent_id":85669599,
     "wof:placetype":"locality",

--- a/data/890/437/791/890437791.geojson
+++ b/data/890/437/791/890437791.geojson
@@ -43,6 +43,9 @@
     "name:pol_x_preferred":[
         "Ratholo"
     ],
+    "name:por_x_preferred":[
+        "Ratholo"
+    ],
     "name:swa_x_preferred":[
         "Ratholo"
     ],
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":890437791,
-    "wof:lastmodified":1566630228,
+    "wof:lastmodified":1690863635,
     "wof:name":"Ratholo",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/890/437/929/890437929.geojson
+++ b/data/890/437/929/890437929.geojson
@@ -55,6 +55,9 @@
     "name:pol_x_preferred":[
         "Metsimotlhaba"
     ],
+    "name:por_x_preferred":[
+        "Metsimotlhabe"
+    ],
     "name:rus_x_preferred":[
         "\u041c\u0435\u0446\u0438\u043c\u043e\u0442\u043b\u0445\u0430\u0431\u0430"
     ],
@@ -65,6 +68,12 @@
         "Metsimotlhabe"
     ],
     "name:swe_x_preferred":[
+        "Metsimotlhabe"
+    ],
+    "name:tsn_x_preferred":[
+        "Metsimotlhabe"
+    ],
+    "name:zul_x_preferred":[
         "Metsimotlhabe"
     ],
     "qs:name":"Metsemotlhaba",
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":890437929,
-    "wof:lastmodified":1566630228,
+    "wof:lastmodified":1690863635,
     "wof:name":"Metsemotlhaba",
     "wof:parent_id":85669611,
     "wof:placetype":"locality",

--- a/data/890/438/467/890438467.geojson
+++ b/data/890/438/467/890438467.geojson
@@ -49,6 +49,9 @@
     "name:pol_x_preferred":[
         "Werda"
     ],
+    "name:por_x_preferred":[
+        "Werda"
+    ],
     "name:rus_x_preferred":[
         "\u0412\u0435\u0440\u0434\u0430"
     ],
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":890438467,
-    "wof:lastmodified":1566630229,
+    "wof:lastmodified":1690863637,
     "wof:name":"Werda",
     "wof:parent_id":85669593,
     "wof:placetype":"locality",

--- a/data/890/439/933/890439933.geojson
+++ b/data/890/439/933/890439933.geojson
@@ -25,11 +25,17 @@
     "name:ara_x_preferred":[
         "\u0644\u0648\u0628\u0627\u062a\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u0644\u0648\u0628\u0627\u062a\u0633"
+    ],
     "name:ast_x_preferred":[
         "Lobatse"
     ],
     "name:azb_x_preferred":[
         "\u0644\u0648\u0628\u0627\u062a\u0633"
+    ],
+    "name:bel_x_preferred":[
+        "\u041b\u0430\u0431\u0430\u0446\u044d"
     ],
     "name:ben_x_preferred":[
         "\u09b2\u09cb\u09ac\u09be\u09ce\u09b8\u09c7"
@@ -175,6 +181,9 @@
     "name:zho_x_preferred":[
         "\u6d1b\u5df4\u7b56"
     ],
+    "name:zul_x_preferred":[
+        "Lobatse"
+    ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Botswana",
     "ne:ADM0_A3":"BWA",
@@ -302,7 +311,7 @@
         }
     ],
     "wof:id":890439933,
-    "wof:lastmodified":1636495626,
+    "wof:lastmodified":1690863634,
     "wof:name":"Lobatse",
     "wof:parent_id":85669639,
     "wof:placetype":"locality",

--- a/data/890/440/373/890440373.geojson
+++ b/data/890/440/373/890440373.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ast_x_preferred":[
+        "Shakawe"
+    ],
     "name:ceb_x_preferred":[
         "Shakawe"
     ],
@@ -58,6 +61,9 @@
     "name:pol_x_preferred":[
         "Shakawe"
     ],
+    "name:por_x_preferred":[
+        "Shakawe"
+    ],
     "name:rus_x_preferred":[
         "\u0428\u0430\u043a\u0430\u0432\u0435"
     ],
@@ -78,6 +84,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6c99\u5361\u97cb"
+    ],
+    "name:zul_x_preferred":[
+        "Shakawe"
     ],
     "qs:name":"Shakawe",
     "qs:photos_9r":0,
@@ -112,7 +121,7 @@
         }
     ],
     "wof:id":890440373,
-    "wof:lastmodified":1566630225,
+    "wof:lastmodified":1690863633,
     "wof:name":"Shakawe",
     "wof:parent_id":85669599,
     "wof:placetype":"locality",

--- a/data/890/441/291/890441291.geojson
+++ b/data/890/441/291/890441291.geojson
@@ -40,6 +40,9 @@
     "name:pol_x_preferred":[
         "Mokobeng"
     ],
+    "name:por_x_preferred":[
+        "Mokobeng"
+    ],
     "name:swa_x_preferred":[
         "Mokobeng"
     ],
@@ -75,7 +78,7 @@
         }
     ],
     "wof:id":890441291,
-    "wof:lastmodified":1566630225,
+    "wof:lastmodified":1690863633,
     "wof:name":"Makobeng",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/890/441/737/890441737.geojson
+++ b/data/890/441/737/890441737.geojson
@@ -37,6 +37,9 @@
     "name:fra_x_preferred":[
         "Tsienyane/Rakops"
     ],
+    "name:ind_x_preferred":[
+        "Rakops"
+    ],
     "name:ita_x_preferred":[
         "Tsienyane/Rakops"
     ],
@@ -49,8 +52,17 @@
     "name:nld_x_preferred":[
         "Tsienyane"
     ],
+    "name:nob_x_preferred":[
+        "Rakops"
+    ],
     "name:pol_x_preferred":[
         "Tsienyane"
+    ],
+    "name:por_x_preferred":[
+        "Rakops"
+    ],
+    "name:rus_x_preferred":[
+        "\u0420\u0430\u043a\u043e\u043f\u0441"
     ],
     "name:spa_x_preferred":[
         "Tsienyane"
@@ -69,6 +81,9 @@
     ],
     "name:zho_x_variant":[
         "\u6c99\u5361\u97cb"
+    ],
+    "name:zul_x_preferred":[
+        "Rakops"
     ],
     "qs:name":"Rakops",
     "qs:photos_9r":0,
@@ -103,7 +118,7 @@
         }
     ],
     "wof:id":890441737,
-    "wof:lastmodified":1566630225,
+    "wof:lastmodified":1690863633,
     "wof:name":"Rakops",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/890/443/483/890443483.geojson
+++ b/data/890/443/483/890443483.geojson
@@ -76,6 +76,9 @@
     "name:pol_x_preferred":[
         "Tsao"
     ],
+    "name:por_x_preferred":[
+        "Tsao"
+    ],
     "name:rus_x_preferred":[
         "\u0426\u0430\u0443"
     ],
@@ -232,7 +235,7 @@
         }
     ],
     "wof:id":890443483,
-    "wof:lastmodified":1636495627,
+    "wof:lastmodified":1690863638,
     "wof:name":"Tsau",
     "wof:parent_id":85669599,
     "wof:placetype":"locality",

--- a/data/890/443/487/890443487.geojson
+++ b/data/890/443/487/890443487.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ast_x_preferred":[
+        "Kopong"
+    ],
     "name:azb_x_preferred":[
         "\u06a9\u0648\u067e\u0648\u0646\u0642"
     ],
@@ -43,6 +46,12 @@
     "name:ita_x_preferred":[
         "Kopong"
     ],
+    "name:jav_x_preferred":[
+        "Kopong"
+    ],
+    "name:mlg_x_preferred":[
+        "Kopong"
+    ],
     "name:nld_x_preferred":[
         "Kopong"
     ],
@@ -50,6 +59,9 @@
         "Kopong"
     ],
     "name:pol_x_preferred":[
+        "Kopong"
+    ],
+    "name:por_x_preferred":[
         "Kopong"
     ],
     "name:rus_x_preferred":[
@@ -72,6 +84,9 @@
     ],
     "name:zho_x_preferred":[
         "\u79d1\u84ec"
+    ],
+    "name:zul_x_preferred":[
+        "Kopong"
     ],
     "qs:name":"Kopong",
     "qs:photos_9r":0,
@@ -106,7 +121,7 @@
         }
     ],
     "wof:id":890443487,
-    "wof:lastmodified":1566630231,
+    "wof:lastmodified":1690863640,
     "wof:name":"Kopong",
     "wof:parent_id":85669611,
     "wof:placetype":"locality",

--- a/data/890/443/489/890443489.geojson
+++ b/data/890/443/489/890443489.geojson
@@ -52,14 +52,26 @@
     "name:pol_x_preferred":[
         "Khudumelapye"
     ],
+    "name:por_x_preferred":[
+        "Khudumelapye"
+    ],
     "name:swa_x_preferred":[
         "Khudumelapye"
     ],
     "name:swe_x_preferred":[
         "Khudumelapye"
     ],
+    "name:tsn_x_preferred":[
+        "Khudumelapye"
+    ],
     "name:und_x_variant":[
         "Kudumalapshwe"
+    ],
+    "name:uzb_x_preferred":[
+        "Khudumelapye"
+    ],
+    "name:zul_x_preferred":[
+        "Khudumelapye"
     ],
     "qs:name":"Khudumelapye",
     "qs:photos_9r":0,
@@ -94,7 +106,7 @@
         }
     ],
     "wof:id":890443489,
-    "wof:lastmodified":1566630231,
+    "wof:lastmodified":1690863640,
     "wof:name":"Khudumelapye",
     "wof:parent_id":85669611,
     "wof:placetype":"locality",

--- a/data/890/443/491/890443491.geojson
+++ b/data/890/443/491/890443491.geojson
@@ -58,6 +58,9 @@
     "name:pol_x_preferred":[
         "Kang"
     ],
+    "name:por_x_preferred":[
+        "Kang"
+    ],
     "name:ron_x_preferred":[
         "Kang"
     ],
@@ -71,6 +74,9 @@
         "Kang"
     ],
     "name:tsn_x_preferred":[
+        "Kang"
+    ],
+    "name:zul_x_preferred":[
         "Kang"
     ],
     "qs:name":"Kang",
@@ -104,7 +110,7 @@
         }
     ],
     "wof:id":890443491,
-    "wof:lastmodified":1566630231,
+    "wof:lastmodified":1690863639,
     "wof:name":"Kang",
     "wof:parent_id":85669593,
     "wof:placetype":"locality",

--- a/data/890/443/493/890443493.geojson
+++ b/data/890/443/493/890443493.geojson
@@ -43,6 +43,9 @@
     "name:pol_x_preferred":[
         "Kalamare"
     ],
+    "name:por_x_preferred":[
+        "Kalamare"
+    ],
     "name:swa_x_preferred":[
         "Kalamare"
     ],
@@ -85,7 +88,7 @@
         }
     ],
     "wof:id":890443493,
-    "wof:lastmodified":1566630231,
+    "wof:lastmodified":1690863640,
     "wof:name":"Kalamare",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/890/443/497/890443497.geojson
+++ b/data/890/443/497/890443497.geojson
@@ -28,6 +28,9 @@
     "name:ast_x_preferred":[
         "Hukuntsi"
     ],
+    "name:azb_x_preferred":[
+        "\u0647\u0648\u06a9\u0648\u0646\u062a\u0633\u06cc"
+    ],
     "name:bar_x_preferred":[
         "Hukuntsi"
     ],
@@ -274,7 +277,7 @@
         }
     ],
     "wof:id":890443497,
-    "wof:lastmodified":1566630230,
+    "wof:lastmodified":1690863639,
     "wof:name":"Hukuntsi",
     "wof:parent_id":85669593,
     "wof:placetype":"locality",

--- a/data/890/443/499/890443499.geojson
+++ b/data/890/443/499/890443499.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:arz_x_preferred":[
+        "\u062c\u0648\u064a\u062a\u0627"
+    ],
     "name:ceb_x_preferred":[
         "Gweta"
     ],
@@ -49,6 +52,12 @@
     "name:pol_x_preferred":[
         "Gweta"
     ],
+    "name:por_x_preferred":[
+        "Gweta"
+    ],
+    "name:pus_x_preferred":[
+        "\u06ab\u0648\u06d0\u062a\u0627"
+    ],
     "name:rus_x_preferred":[
         "\u0413\u0432\u0435\u0442\u0430"
     ],
@@ -62,6 +71,9 @@
         "Gweta"
     ],
     "name:tsn_x_preferred":[
+        "Gweta"
+    ],
+    "name:zul_x_preferred":[
         "Gweta"
     ],
     "qs:name":"Gweta",
@@ -97,7 +109,7 @@
         }
     ],
     "wof:id":890443499,
-    "wof:lastmodified":1566630231,
+    "wof:lastmodified":1690863639,
     "wof:name":"Gweta",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/890/443/501/890443501.geojson
+++ b/data/890/443/501/890443501.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":10.0,
+    "name:ast_x_preferred":[
+        "Gabane"
+    ],
     "name:azb_x_preferred":[
         "\u0642\u0627\u0628\u0627\u0646"
     ],
@@ -26,6 +29,9 @@
         "Gabane"
     ],
     "name:ceb_x_preferred":[
+        "Gabane"
+    ],
+    "name:deu_x_preferred":[
         "Gabane"
     ],
     "name:eng_x_preferred":[
@@ -58,6 +64,12 @@
     "name:pol_x_preferred":[
         "Gabane"
     ],
+    "name:por_x_preferred":[
+        "Gabane"
+    ],
+    "name:pus_x_preferred":[
+        "\u06af\u0627\u0628\u0627\u0646"
+    ],
     "name:rus_x_preferred":[
         "\u0413\u0430\u0431\u0430\u043d\u0435"
     ],
@@ -78,6 +90,9 @@
     ],
     "name:zho_x_preferred":[
         "\u54c8\u5df4\u5167"
+    ],
+    "name:zul_x_preferred":[
+        "Gabane"
     ],
     "qs:name":"Gabane",
     "qs:photos_9r":0,
@@ -112,7 +127,7 @@
         }
     ],
     "wof:id":890443501,
-    "wof:lastmodified":1566630231,
+    "wof:lastmodified":1690863639,
     "wof:name":"Gabane",
     "wof:parent_id":85669611,
     "wof:placetype":"locality",

--- a/data/890/443/505/890443505.geojson
+++ b/data/890/443/505/890443505.geojson
@@ -40,6 +40,9 @@
     "name:pol_x_preferred":[
         "Dutlwe"
     ],
+    "name:por_x_preferred":[
+        "Dutlwe"
+    ],
     "name:swa_x_preferred":[
         "Dutlwe"
     ],
@@ -51,6 +54,9 @@
     ],
     "name:und_x_variant":[
         "Luzwe"
+    ],
+    "name:uzb_x_preferred":[
+        "Dutlwe"
     ],
     "qs:name":"Dutlwe",
     "qs:photos_9r":0,
@@ -85,7 +91,7 @@
         }
     ],
     "wof:id":890443505,
-    "wof:lastmodified":1566630230,
+    "wof:lastmodified":1690863638,
     "wof:name":"Dutlwe",
     "wof:parent_id":85669611,
     "wof:placetype":"locality",

--- a/data/890/443/509/890443509.geojson
+++ b/data/890/443/509/890443509.geojson
@@ -49,6 +49,9 @@
     "name:pol_x_preferred":[
         "Dekar"
     ],
+    "name:por_x_preferred":[
+        "Dekar"
+    ],
     "name:swa_x_preferred":[
         "Dekar"
     ],
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":890443509,
-    "wof:lastmodified":1566630231,
+    "wof:lastmodified":1690863639,
     "wof:name":"Dekar",
     "wof:parent_id":85669589,
     "wof:placetype":"locality",

--- a/data/890/454/095/890454095.geojson
+++ b/data/890/454/095/890454095.geojson
@@ -55,6 +55,9 @@
     "name:pol_x_preferred":[
         "Bokaa"
     ],
+    "name:por_x_preferred":[
+        "Bokaa"
+    ],
     "name:rus_x_preferred":[
         "\u0411\u043e\u043a\u0430\u0430"
     ],
@@ -68,6 +71,9 @@
         "Bokaa"
     ],
     "name:tsn_x_preferred":[
+        "Bokaa"
+    ],
+    "name:zul_x_preferred":[
         "Bokaa"
     ],
     "qs:name":"Bokaa",
@@ -103,7 +109,7 @@
         }
     ],
     "wof:id":890454095,
-    "wof:lastmodified":1566630230,
+    "wof:lastmodified":1690863638,
     "wof:name":"Bokaa",
     "wof:parent_id":85669607,
     "wof:placetype":"locality",

--- a/data/890/454/097/890454097.geojson
+++ b/data/890/454/097/890454097.geojson
@@ -43,6 +43,9 @@
     "name:pol_x_preferred":[
         "Boatlaname"
     ],
+    "name:por_x_preferred":[
+        "Boatlaname"
+    ],
     "name:swa_x_preferred":[
         "Boatlaname"
     ],
@@ -50,6 +53,9 @@
         "Boatlaname"
     ],
     "name:tsn_x_preferred":[
+        "Boatlaname"
+    ],
+    "name:uzb_x_preferred":[
         "Boatlaname"
     ],
     "qs:name":"Boatlaname",
@@ -85,7 +91,7 @@
         }
     ],
     "wof:id":890454097,
-    "wof:lastmodified":1566630230,
+    "wof:lastmodified":1690863637,
     "wof:name":"Boatlaname",
     "wof:parent_id":85669611,
     "wof:placetype":"locality",

--- a/data/890/454/145/890454145.geojson
+++ b/data/890/454/145/890454145.geojson
@@ -43,10 +43,16 @@
     "name:pol_x_preferred":[
         "Tlhareseleele"
     ],
+    "name:por_x_preferred":[
+        "Tlhareseleele"
+    ],
     "name:swa_x_preferred":[
         "Tlhareseleele"
     ],
     "name:swe_x_preferred":[
+        "Tlhareseleele"
+    ],
+    "name:tsn_x_preferred":[
         "Tlhareseleele"
     ],
     "qs:name":"Tlhareselele",
@@ -74,7 +80,7 @@
         }
     ],
     "wof:id":890454145,
-    "wof:lastmodified":1566630230,
+    "wof:lastmodified":1690863637,
     "wof:name":"Tlhareselele",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/454/149/890454149.geojson
+++ b/data/890/454/149/890454149.geojson
@@ -43,6 +43,9 @@
     "name:pol_x_preferred":[
         "Moremi"
     ],
+    "name:por_x_preferred":[
+        "Moremi"
+    ],
     "name:swa_x_preferred":[
         "Moremi"
     ],
@@ -83,7 +86,7 @@
         }
     ],
     "wof:id":890454149,
-    "wof:lastmodified":1566630230,
+    "wof:lastmodified":1690863638,
     "wof:name":"Moremi",
     "wof:parent_id":85669601,
     "wof:placetype":"locality",

--- a/data/890/455/181/890455181.geojson
+++ b/data/890/455/181/890455181.geojson
@@ -28,6 +28,9 @@
     "name:ceb_x_preferred":[
         "Bokspits"
     ],
+    "name:deu_x_preferred":[
+        "Bokspits"
+    ],
     "name:ell_x_preferred":[
         "\u039c\u03c0\u03cc\u03ba\u03c3\u03c0\u03b9\u03c4\u03c2"
     ],
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":890455181,
-    "wof:lastmodified":1566630228,
+    "wof:lastmodified":1690863636,
     "wof:name":"Bokspits",
     "wof:parent_id":1108730597,
     "wof:placetype":"locality",

--- a/data/890/455/183/890455183.geojson
+++ b/data/890/455/183/890455183.geojson
@@ -22,6 +22,9 @@
     "name:ceb_x_preferred":[
         "Bogo Gobo"
     ],
+    "name:deu_x_preferred":[
+        "Bogogobo"
+    ],
     "name:eng_x_preferred":[
         "Bogogobo"
     ],
@@ -38,6 +41,9 @@
         "Bogogobo"
     ],
     "name:pol_x_preferred":[
+        "Bogogobo"
+    ],
+    "name:por_x_preferred":[
         "Bogogobo"
     ],
     "name:swa_x_preferred":[
@@ -78,7 +84,7 @@
         }
     ],
     "wof:id":890455183,
-    "wof:lastmodified":1566630229,
+    "wof:lastmodified":1690863636,
     "wof:name":"Bogo Gobo",
     "wof:parent_id":85669593,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.