### PR TITLE
bw concordances, placetype local, and more

### DIFF
--- a/data/421/170/305/421170305.geojson
+++ b/data/421/170/305/421170305.geojson
@@ -84,7 +84,7 @@
         }
     ],
     "wof:id":421170305,
-    "wof:lastmodified":1694492294,
+    "wof:lastmodified":1695886972,
     "wof:name":"Kabe",
     "wof:parent_id":85669599,
     "wof:placetype":"county",

--- a/data/421/186/333/421186333.geojson
+++ b/data/421/186/333/421186333.geojson
@@ -85,7 +85,7 @@
     },
     "wof:country":"BW",
     "wof:created":1459009477,
-    "wof:geomhash":"57ccb6272c38fbc53c9d345b68ed5b1d",
+    "wof:geomhash":"ef8fbeb14a33001f6992f3f18a5ec951",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -95,7 +95,7 @@
         }
     ],
     "wof:id":421186333,
-    "wof:lastmodified":1690863626,
+    "wof:lastmodified":1695886972,
     "wof:name":"Katima Mulilo Rural",
     "wof:parent_id":85669599,
     "wof:placetype":"county",

--- a/data/421/190/669/421190669.geojson
+++ b/data/421/190/669/421190669.geojson
@@ -188,7 +188,7 @@
     },
     "wof:country":"BW",
     "wof:created":1459009665,
-    "wof:geomhash":"3fca74f950972ef4d8d5529b758c062d",
+    "wof:geomhash":"1a00188562ed8c36388d209af86e805e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -198,7 +198,7 @@
         }
     ],
     "wof:id":421190669,
-    "wof:lastmodified":1690863628,
+    "wof:lastmodified":1695887131,
     "wof:name":"Beitbridge",
     "wof:parent_id":85669601,
     "wof:placetype":"county",

--- a/data/856/322/35/85632235.geojson
+++ b/data/856/322/35/85632235.geojson
@@ -1192,6 +1192,7 @@
         "hasc:id":"BW",
         "icao:code":"A2",
         "ioc:id":"BOT",
+        "iso:code":"BW",
         "itu:id":"BOT",
         "loc:id":"n79079238",
         "m49:code":"072",
@@ -1206,6 +1207,7 @@
         "wk:page":"Botswana",
         "wmo:id":"BC"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BW",
     "wof:country_alpha3":"BWA",
     "wof:geom_alt":[
@@ -1228,7 +1230,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1694639509,
+    "wof:lastmodified":1695881163,
     "wof:name":"Botswana",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/695/89/85669589.geojson
+++ b/data/856/695/89/85669589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":10.064273,
-    "geom:area_square_m":115176606557.765533,
+    "geom:area_square_m":115176626218.907043,
     "geom:bbox":"19.978346,-23.318525,25.439305,-20.999958",
     "geom:latitude":-22.294149,
     "geom:longitude":22.590536,
@@ -315,14 +315,16 @@
         "gn:id":933758,
         "gp:id":2344743,
         "hasc:id":"BW.GH",
+        "iso:code":"BW-GH",
         "iso:id":"BW-GH",
         "qs_pg:id":219503,
         "unlc:id":"BW-GH",
         "wd:id":"Q57571",
         "wk:page":"Ghanzi District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BW",
-    "wof:geomhash":"3c9c78ff66695fc5bc49a3ca19be7bf7",
+    "wof:geomhash":"025dbcfe3c30bd936a4d5c2199f2b92b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -339,7 +341,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1690863616,
+    "wof:lastmodified":1695884802,
     "wof:name":"Ghanzi",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/695/93/85669593.geojson
+++ b/data/856/695/93/85669593.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.433898,
-    "geom:area_square_m":105833832574.242538,
+    "geom:area_square_m":105833823532.053192,
     "geom:bbox":"19.979855,-26.891794,24.500851,-23.308551",
     "geom:latitude":-24.854491,
     "geom:longitude":21.742081,
@@ -309,14 +309,16 @@
         "gn:id":933657,
         "gp:id":2344744,
         "hasc:id":"BW.KG",
+        "iso:code":"BW-KG",
         "iso:id":"BW-KG",
         "qs_pg:id":235562,
         "unlc:id":"BW-KG",
         "wd:id":"Q57581",
         "wk:page":"Kgalagadi District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BW",
-    "wof:geomhash":"f1a5059408f33f7ca2f8b09f3d80bd39",
+    "wof:geomhash":"390a7eed20a77ed948c69d9d99cfc379",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -333,7 +335,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1690863616,
+    "wof:lastmodified":1695884802,
     "wof:name":"Kgalagadi",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/695/99/85669599.geojson
+++ b/data/856/695/99/85669599.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":11.45708,
-    "geom:area_square_m":133580513303.74054,
+    "geom:area_square_m":133580506268.745209,
     "geom:bbox":"20.975081,-20.999958,25.967449,-17.781808",
     "geom:latitude":-19.438262,
     "geom:longitude":23.07702,
@@ -291,14 +291,16 @@
         "gn:id":933230,
         "gp:id":55949048,
         "hasc:id":"BW.NC",
+        "iso:code":"BW-NW",
         "iso:id":"BW-NW",
         "qs_pg:id":893115,
         "unlc:id":"BW-NW",
         "wd:id":"Q57617",
         "wk:page":"North-West District (Botswana)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BW",
-    "wof:geomhash":"cf78305491ee6eb2fa8cfeba3345d4e7",
+    "wof:geomhash":"8e3e03b96dc0738f0e18e4aff071b259",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -315,7 +317,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1690863617,
+    "wof:lastmodified":1695884802,
     "wof:name":"North-West",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/696/01/85669601.geojson
+++ b/data/856/696/01/85669601.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":12.741557,
-    "geom:area_square_m":146480154843.773865,
+    "geom:area_square_m":146480161271.769165,
     "geom:bbox":"23.879039,-23.947892,29.350074,-18.999925",
     "geom:latitude":-21.540061,
     "geom:longitude":26.269901,
@@ -318,13 +318,15 @@
         "gn:id":933851,
         "gp:id":2344741,
         "hasc:id":"BW.CT",
+        "iso:code":"BW-CE",
         "iso:id":"BW-CE",
         "qs_pg:id":219502,
         "wd:id":"Q57525",
         "wk:page":"Central District (Botswana)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BW",
-    "wof:geomhash":"453c67fd44341cc0f6033b3f2bb471c2",
+    "wof:geomhash":"488c25813158ed150447cbd4c8644b53",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -341,7 +343,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1690863621,
+    "wof:lastmodified":1695884802,
     "wof:name":"Central",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/696/07/85669607.geojson
+++ b/data/856/696/07/85669607.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.683059,
-    "geom:area_square_m":7708022405.788254,
+    "geom:area_square_m":7708026432.604767,
     "geom:bbox":"25.886203,-24.660846,26.966602,-23.566261",
     "geom:latitude":-24.144956,
     "geom:longitude":26.348682,
@@ -303,14 +303,16 @@
         "gn:id":933654,
         "gp:id":2344745,
         "hasc:id":"BW.KL",
+        "iso:code":"BW-KL",
         "iso:id":"BW-KL",
         "qs_pg:id":219504,
         "unlc:id":"BW-KL",
         "wd:id":"Q57593",
         "wk:page":"Kgatleng District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BW",
-    "wof:geomhash":"9c09f6dce658e68215430e35648187c8",
+    "wof:geomhash":"581b343e142f80a2a8acec3a1b3a2016",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -327,7 +329,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1690863620,
+    "wof:lastmodified":1695884802,
     "wof:name":"Kgatleng",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/696/11/85669611.geojson
+++ b/data/856/696/11/85669611.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.274425,
-    "geom:area_square_m":37024603221.711517,
+    "geom:area_square_m":37024591258.69368,
     "geom:bbox":"22.955426,-24.769082,26.020407,-22.95188",
     "geom:latitude":-23.862913,
     "geom:longitude":24.685166,
@@ -306,14 +306,16 @@
         "gn:id":933562,
         "gp:id":2344746,
         "hasc:id":"BW.KW",
+        "iso:code":"BW-KW",
         "iso:id":"BW-KW",
         "qs_pg:id":423576,
         "unlc:id":"BW-KW",
         "wd:id":"Q57599",
         "wk:page":"Kweneng District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BW",
-    "wof:geomhash":"12e25fc1b0d6d0d409e272766ef57db1",
+    "wof:geomhash":"a0f0f1ff2e9c7446f3cd918b08e00a59",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -330,7 +332,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1690863619,
+    "wof:lastmodified":1695884802,
     "wof:name":"Kweneng",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/696/15/85669615.geojson
+++ b/data/856/696/15/85669615.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.144562,
-    "geom:area_square_m":1620421270.682205,
+    "geom:area_square_m":1620422918.181494,
     "geom:bbox":"25.542348,-25.463319,26.165911,-24.558915",
     "geom:latitude":-24.980279,
     "geom:longitude":25.759397,
@@ -291,13 +291,15 @@
         "gn:id":933044,
         "gp:id":2344749,
         "hasc:id":"BW.SR",
+        "iso:code":"BW-SE",
         "iso:id":"BW-SE",
         "qs_pg:id":219505,
         "wd:id":"Q57695",
         "wk:page":"South-East District (Botswana)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BW",
-    "wof:geomhash":"fbd4d6e6281202d4ffdf1720c8bbb097",
+    "wof:geomhash":"bb15b9355c20111c4b03ff3cf7af3a5e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -314,7 +316,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1690863621,
+    "wof:lastmodified":1695884802,
     "wof:name":"South-East",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/696/19/85669619.geojson
+++ b/data/856/696/19/85669619.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.413879,
-    "geom:area_square_m":27069037666.574669,
+    "geom:area_square_m":27069041797.491013,
     "geom:bbox":"23.049322,-25.829223,25.687249,-23.999103",
     "geom:latitude":-24.928394,
     "geom:longitude":24.459159,
@@ -310,13 +310,15 @@
         "gn:id":933043,
         "gp:id":2344750,
         "hasc:id":"BW.SN",
+        "iso:code":"BW-SO",
         "iso:id":"BW-SO",
         "qs_pg:id":279860,
         "wd:id":"Q57609",
         "wk:page":"Southern District (Botswana)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BW",
-    "wof:geomhash":"04ad185ca9e476a491826a52481d3da7",
+    "wof:geomhash":"1e0057501fe4ad7dab382d0451b4f8df",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -333,7 +335,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1690863620,
+    "wof:lastmodified":1695884802,
     "wof:name":"Southern",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/696/27/85669627.geojson
+++ b/data/856/696/27/85669627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.453588,
-    "geom:area_square_m":5236153887.245198,
+    "geom:area_square_m":5236153956.066666,
     "geom:bbox":"27.215246,-21.551913,27.990415,-20.473013",
     "geom:latitude":-20.99838,
     "geom:longitude":27.539594,
@@ -287,13 +287,15 @@
         "gn:id":933210,
         "gp:id":2344748,
         "hasc:id":"BW.NR",
+        "iso:code":"BW-NE",
         "iso:id":"BW-NE",
         "qs_pg:id":229362,
         "wd:id":"Q57636",
         "wk:page":"North-East District (Botswana)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BW",
-    "wof:geomhash":"d2aec5811155a09efc847e2228c1106a",
+    "wof:geomhash":"bd77f5c8927f14c5bd25a7bfa123594b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -310,7 +312,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1690863619,
+    "wof:lastmodified":1695884802,
     "wof:name":"North-East",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/696/31/85669631.geojson
+++ b/data/856/696/31/85669631.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025424,
-    "geom:area_square_m":285806966.089497,
+    "geom:area_square_m":285806966.089486,
     "geom:bbox":"25.834928,-24.71617,26.033354,-24.507444",
     "geom:latitude":-24.61903,
     "geom:longitude":25.931178,
@@ -226,12 +226,14 @@
         "fips:code":"BC14",
         "gp:id":2344749,
         "hasc:id":"BW.GB",
+        "iso:code":"BW-GA",
         "iso:id":"BW-GA",
         "unlc:id":"BW-GA",
         "wd:id":"Q57695"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BW",
-    "wof:geomhash":"60f25d83e14931c3ff581825c133a4db",
+    "wof:geomhash":"9bbd9ed8a86e1f5f569a9282b88d736c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -248,7 +250,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1690863620,
+    "wof:lastmodified":1695884442,
     "wof:name":"Gaborone",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/696/35/85669635.geojson
+++ b/data/856/696/35/85669635.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007838,
-    "geom:area_square_m":90378565.507456,
+    "geom:area_square_m":90378530.126597,
     "geom:bbox":"27.442505,-21.215799,27.559313,-21.106897",
     "geom:latitude":-21.169941,
     "geom:longitude":27.50629,
@@ -282,12 +282,14 @@
         "gn:id":-933210,
         "gp:id":-2344748,
         "hasc:id":"BW.FR",
+        "iso:code":"BW-FR",
         "iso:id":"BW-FR",
         "unlc:id":"BW-FR",
         "wd:id":"Q57636"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BW",
-    "wof:geomhash":"f2b7a4e7a3dbce6661da7a02ed040af7",
+    "wof:geomhash":"b51b33b59e948cc17b55959c672bcae7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -304,7 +306,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1690863619,
+    "wof:lastmodified":1695884802,
     "wof:name":"Francistown",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/696/39/85669639.geojson
+++ b/data/856/696/39/85669639.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001758,
-    "geom:area_square_m":19664371.889014,
+    "geom:area_square_m":19664453.683584,
     "geom:bbox":"25.659341,-25.238966,25.705597,-25.171811",
     "geom:latitude":-25.210169,
     "geom:longitude":25.685218,
@@ -301,12 +301,14 @@
         "fips:code":"BC16",
         "gp:id":2344749,
         "hasc:id":"BW.LB",
+        "iso:code":"BW-LO",
         "iso:id":"BW-LO",
         "unlc:id":"BW-LO",
         "wd:id":"Q57695"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BW",
-    "wof:geomhash":"473d73ec68366323aed6c79edb3a7b0a",
+    "wof:geomhash":"97d3e10811f891f36f6f60086b56fc81",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -323,7 +325,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1690863621,
+    "wof:lastmodified":1695884802,
     "wof:name":"Lobatse",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/696/45/85669645.geojson
+++ b/data/856/696/45/85669645.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003041,
-    "geom:area_square_m":34872207.55578,
+    "geom:area_square_m":34872525.596365,
     "geom:bbox":"27.807761,-21.996966,27.882886,-21.920742",
     "geom:latitude":-21.965815,
     "geom:longitude":27.847954,
@@ -253,11 +253,13 @@
         "fips:code":"BC17",
         "gp:id":2344741,
         "hasc:id":"BW.SP",
+        "iso:code":"BW-SP",
         "iso:id":"BW-SP",
         "wd:id":"Q57525"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BW",
-    "wof:geomhash":"14c0c722bb30f72bd995a9fa5633306c",
+    "wof:geomhash":"257fccf5531c7f7e8fe4d5db05cd81ce",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -274,7 +276,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1690863619,
+    "wof:lastmodified":1695884802,
     "wof:name":"Selebi-Phikwe",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/696/49/85669649.geojson
+++ b/data/856/696/49/85669649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004746,
-    "geom:area_square_m":54944556.753069,
+    "geom:area_square_m":54944708.001267,
     "geom:bbox":"26.120432,-20.598644,26.256001,-20.544585",
     "geom:latitude":-20.571414,
     "geom:longitude":26.193968,
@@ -263,11 +263,13 @@
         "fips:code":"BC18",
         "gp:id":2344741,
         "hasc:id":"BW.ST",
+        "iso:code":"BW-ST",
         "iso:id":"BW-ST",
         "wd:id":"Q57525"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BW",
-    "wof:geomhash":"6a81fcae39ff1d5444f8ee17f0b9d9a2",
+    "wof:geomhash":"0329dec16d345a6540da6b785b2c0d26",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -284,7 +286,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1690863622,
+    "wof:lastmodified":1695884802,
     "wof:name":"Sowa",
     "wof:parent_id":85632235,
     "wof:placetype":"region",

--- a/data/856/696/53/85669653.geojson
+++ b/data/856/696/53/85669653.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030222,
-    "geom:area_square_m":339864243.2223,
+    "geom:area_square_m":339864436.014563,
     "geom:bbox":"24.637647,-24.660326,24.820578,-24.461185",
     "geom:latitude":-24.571506,
     "geom:longitude":24.722615,
@@ -303,12 +303,14 @@
         "gn:id":-933043,
         "gp:id":-2344750,
         "hasc:id":"BW.JW",
+        "iso:code":"BW-JW",
         "iso:id":"BW-JW",
         "unlc:id":"BW-JW",
         "wd:id":"Q57609"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BW",
-    "wof:geomhash":"b278e166e702c9e8fb2c35a8b00a42fc",
+    "wof:geomhash":"d3744d3a9b5a12244023f972ac3a5e9f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -325,7 +327,7 @@
         "eng",
         "tsn"
     ],
-    "wof:lastmodified":1690863621,
+    "wof:lastmodified":1695884802,
     "wof:name":"Jwaneng",
     "wof:parent_id":85632235,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.